### PR TITLE
Remove obsolete `category` option of components

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Alert',
   icon: 'AlertIcon',
-  category: 'CONTENT',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Box',
   icon: 'ContainerIcon',
-  category: 'LAYOUT',
   type: 'CONTAINER_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/breadcrumb.js
+++ b/src/components/breadcrumb.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Breadcrumb',
   icon: 'BreadcrumbIcon',
-  category: 'NAVIGATION',
   type: 'CONTENT_COMPONENT',
   allowedTypes: ['BREADCRUMB_ITEM'],
   orientation: 'HORIZONTAL',

--- a/src/components/breadcrumbItem.js
+++ b/src/components/breadcrumbItem.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'BreadcrumbItem',
   icon: 'BreadcrumbItemIcon',
-  category: 'NAVIGATION',
   type: 'BREADCRUMB_ITEM',
   allowedTypes: [],
   orientation: 'VERTICAL',

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Button',
   icon: 'ButtonIcon',
-  category: 'CONTENT',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'VERTICAL',

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Checkbox',
   type: 'CONTENT_COMPONENT',
-  category: 'FORM',
   allowedTypes: [],
   orientation: 'HORIZONTAL',
   jsx: (() => {

--- a/src/components/column.js
+++ b/src/components/column.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Column',
   icon: 'ColumnIcon',
-  category: 'LAYOUT',
   type: 'LAYOUT_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'VERTICAL',

--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'DataContainer',
   icon: 'DataContainer',
-  category: 'CONTENT',
   type: 'CONTAINER_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/dataList.js
+++ b/src/components/dataList.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'DataList',
   icon: 'DataList',
-  category: 'CONTENT',
   type: 'CONTAINER_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'DataTable',
   icon: 'DataTable',
-  category: 'DATA',
   type: 'CONTENT_COMPONENT',
   allowedTypes: ['DATATABLE_COLUMN'],
   orientation: 'HORIZONTAL',

--- a/src/components/dataTableColumn.js
+++ b/src/components/dataTableColumn.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'DataTableColumn',
   icon: 'DataTableColumnIcon',
-  category: 'DATATABLE',
   type: 'DATATABLE_COLUMN',
   allowedTypes: ['CONTENT_COMPONENT'],
   orientation: 'VERTICAL',

--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'DateTimePicker',
   icon: 'DateTimePickerIcon',
-  category: 'FORM',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',

--- a/src/components/divider.js
+++ b/src/components/divider.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Divider',
   icon: 'HorizontalRuleIcon',
-  category: 'CONTENT',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Form',
   icon: 'FormIcon',
-  category: 'FORM',
   type: 'CONTAINER_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/image.js
+++ b/src/components/image.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Image',
   icon: 'ImageIcon',
-  category: 'CONTENT',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'VERTICAL',

--- a/src/components/navigationBar.js
+++ b/src/components/navigationBar.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'NavigationBar',
   icon: 'NavbarIcon',
-  category: 'NAVIGATION',
   type: 'BODY_COMPONENT',
   allowedTypes: ['NAVIGATION_ITEM'],
   orientation: 'HORIZONTAL',

--- a/src/components/navigationItem.js
+++ b/src/components/navigationItem.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'NavigationItem',
   icon: 'NavItemIcon',
-  category: 'NAVIGATION',
   type: 'NAVIGATION_ITEM',
   allowedTypes: [],
   orientation: 'VERTICAL',

--- a/src/components/panel.js
+++ b/src/components/panel.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Panel',
   icon: 'PanelIcon',
-  category: 'LAYOUT',
   type: 'CONTAINER_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'RadioGroup',
   type: 'CONTENT_COMPONENT',
-  category: 'FORM',
   allowedTypes: [],
   orientation: 'HORIZONTAL',
   jsx: (() => {

--- a/src/components/row.js
+++ b/src/components/row.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Row',
   icon: 'RowIcon',
-  category: 'LAYOUT',
   type: 'BODY_COMPONENT',
   allowedTypes: ['LAYOUT_COMPONENT'],
   orientation: 'HORIZONTAL',

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -1,6 +1,5 @@
 (() => ({
   name: 'Select',
-  category: 'FORM',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',

--- a/src/components/text.js
+++ b/src/components/text.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'Text',
   icon: 'HeadingIcon',
-  category: 'CONTENT',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',

--- a/src/components/textField.js
+++ b/src/components/textField.js
@@ -1,7 +1,6 @@
 (() => ({
   name: 'TextField',
   icon: 'TextInputIcon',
-  category: 'FORM',
   type: 'CONTENT_COMPONENT',
   allowedTypes: [],
   orientation: 'HORIZONTAL',


### PR DESCRIPTION
Prefabs support the 'category' option, components don't.