### PR TITLE
Feat/appbar logo width option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.30.3](https://github.com/bettyblocks/material-ui-component-set/compare/v1.30.2...v1.30.3) (2020-08-10)
+
+
+### Bug Fixes
+
+* form action error message passed ([ed157b2](https://github.com/bettyblocks/material-ui-component-set/commit/ed157b2faff0a7c43c5e43c67af09c0db42dd7f7))
+
 ## [1.30.2](https://github.com/bettyblocks/material-ui-component-set/compare/v1.30.1...v1.30.2) (2020-08-05)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "1.30.2",
+  "version": "1.30.3",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/appBar.js
+++ b/src/components/appBar.js
@@ -16,6 +16,7 @@
       position,
       title,
       logoSource,
+      logoWidth,
       endpoint,
       appBarVariant,
       toolbarVariant,
@@ -36,7 +37,7 @@
     };
 
     const logo = useText(logoSource);
-    const LogoCmp = logo && <img src={logo} width="100" alt="" />;
+    const LogoCmp = logo && <img src={logo} width={logoWidth} alt="" />;
     const LogoComponent = endpoint.id ? (
       // eslint-disable-next-line jsx-a11y/anchor-is-valid
       <Link endpoint={endpoint}>{LogoCmp}</Link>

--- a/src/prefabs/appBar.js
+++ b/src/prefabs/appBar.js
@@ -64,6 +64,12 @@
           type: 'VARIABLE',
         },
         {
+          label: 'Logo width',
+          key: 'logoWidth',
+          value: '100',
+          type: 'TEXT',
+        },
+        {
           label: 'Align items',
           key: 'alignItems',
           value: 'right',


### PR DESCRIPTION
We needed the width of the logo to be set to something else than the '100' it was now. I think this will be a nice addition to the default component. Please let me know if I can improve something about this pull request :).

Thanks!