### PR TITLE
fix: enable appBar title to have variables

### DIFF
--- a/src/components/appBar.js
+++ b/src/components/appBar.js
@@ -26,6 +26,7 @@
     const isDev = env === 'dev';
     const [anchorEl, setAnchorEl] = useState(null);
     const open = !!anchorEl;
+    title = useText(title);
 
     const handleMenu = event => {
       setAnchorEl(event.currentTarget);


### PR DESCRIPTION
Added useText for the title option, so app bar doesn't break when selecting a variable