### PR TITLE
Fix expansion panel bug TA-1854

### DIFF
--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -63,12 +63,16 @@
       variant,
       elevation: variant === 'flat' ? 0 : elevation,
       expanded,
+    };
+
+    const panelSummaryOptions = {
       onClick,
+      expandIcon: <ExpandMore />,
     };
 
     const ExpansionPanelComponent = (
       <ExpansionPanel {...panelOptions}>
-        <ExpansionPanelSummary expandIcon={<ExpandMore />}>
+        <ExpansionPanelSummary {...panelSummaryOptions}>
           <Typography>{useText(title)}</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails>


### PR DESCRIPTION
change the `onClick` to the panel summary, instead of the entire panel.