### PR TITLE
feat: split up dateTimePicker to 3 prefabs, with correct options

### DIFF
--- a/src/prefabs/datePicker.js
+++ b/src/prefabs/datePicker.js
@@ -1,6 +1,6 @@
 (() => ({
-  name: 'DateTimePicker',
-  icon: 'DateTimePickerIcon',
+  name: 'DatePicker',
+  icon: 'DatePickerIcon',
   category: 'FORM',
   structure: [
     {
@@ -44,7 +44,7 @@
         {
           label: 'Type',
           key: 'type',
-          value: 'datetime',
+          value: 'date',
           type: 'CUSTOM',
           configuration: {
             condition: {
@@ -68,19 +68,10 @@
           type: 'VARIABLE',
         },
         {
-          value: 'MM/dd/yyyy HH:mm:ss',
+          value: 'MM/dd/yyyy',
           label: 'Format',
-          key: 'dateTimeFormat',
+          key: 'dateFormat',
           type: 'TEXT',
-          configuration: {
-            placeholder: 'MM/dd/yyyy HH:mm:ss',
-            condition: {
-              type: 'SHOW',
-              option: 'type',
-              comparator: 'EQ',
-              value: 'datetime',
-            },
-          },
         },
         {
           value: '',

--- a/src/prefabs/timePicker.js
+++ b/src/prefabs/timePicker.js
@@ -1,6 +1,6 @@
 (() => ({
-  name: 'DateTimePicker',
-  icon: 'DateTimePickerIcon',
+  name: 'TimePicker',
+  icon: 'TimePickerIcon',
   category: 'FORM',
   structure: [
     {
@@ -44,7 +44,7 @@
         {
           label: 'Type',
           key: 'type',
-          value: 'datetime',
+          value: 'time',
           type: 'CUSTOM',
           configuration: {
             condition: {
@@ -68,19 +68,10 @@
           type: 'VARIABLE',
         },
         {
-          value: 'MM/dd/yyyy HH:mm:ss',
+          value: 'HH:mm:ss',
           label: 'Format',
-          key: 'dateTimeFormat',
+          key: 'timeFormat',
           type: 'TEXT',
-          configuration: {
-            placeholder: 'MM/dd/yyyy HH:mm:ss',
-            condition: {
-              type: 'SHOW',
-              option: 'type',
-              comparator: 'EQ',
-              value: 'datetime',
-            },
-          },
         },
         {
           value: '',


### PR DESCRIPTION
Split up the dateTimePicker prefab into:
- DatePicker
- TimePicker
- DateTimePicker

Each prefab has the correct corresponding name, icon, type, and format.