### PR TITLE
fix: timePicker icon fix

### DIFF
--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -36,6 +36,7 @@
       KeyboardDateTimePicker,
     } = window.MaterialUI.Pickers;
     const { DateFnsUtils } = window.MaterialUI;
+    const { AccessTime, Event } = window.MaterialUI.Icons;
     const { useText, getProperty, env, getCustomModelAttribute } = B;
     const DateFns = new DateFnsUtils();
     const isDev = env === 'dev';
@@ -162,6 +163,7 @@
           className: classes.dialog,
         }}
         ampm={!use24HourClock}
+        keyboardIcon={type === 'time' ? <AccessTime /> : <Event />}
       />
     );
 


### PR DESCRIPTION
When the type (defined in the prefab) is `time` an `<AccessTime />` icon will be shown instead of the `<Event />` icon. 
Previously:
<img width="497" alt="Screen Shot 2020-09-21 at 18 45 39" src="https://user-images.githubusercontent.com/6746411/93796279-ea741400-fc3a-11ea-9866-7a422de68bce.png">
Now:
<img width="495" alt="Screen Shot 2020-09-21 at 18 45 59" src="https://user-images.githubusercontent.com/6746411/93796287-ed6f0480-fc3a-11ea-9f3e-1a92d7297748.png">
