### PR TITLE
Make data container a BODY_COMPONENT

### DIFF
--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -1,6 +1,6 @@
 (() => ({
   name: 'DataContainer',
-  type: 'CONTAINER_COMPONENT',
+  type: 'BODY_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',
   jsx: (


### PR DESCRIPTION
Data container are used to create a context but you have to nest them in a column. Some times you need the data container context for the complete page and then it's easier design wise if you do not have to unnecessarily nest it in a column. Because it's no also a me container this becomes even more true. This way it also works better with drawers for example. 