### PR TITLE
Feat/form add onactiondone trigger

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -98,7 +98,7 @@
 
         const trigger = (data, loading, error) => {
           if (data || error) {
-            B.triggerEvent('onActionDone', loading);
+            B.triggerEvent('onActionDone');
           }
 
           if (data) {

--- a/src/components/form.js
+++ b/src/components/form.js
@@ -97,6 +97,10 @@
         };
 
         const trigger = (data, loading, error) => {
+          if (data || error) {
+            B.triggerEvent('onActionDone', loading);
+          }
+
           if (data) {
             B.triggerEvent('onActionSuccess', data.actionb5);
 


### PR DESCRIPTION
Added 
` const trigger = (data, loading, error) => {
          if (data || error) {
            B.triggerEvent('onActionDone', loading);
          }`
To decrease the number of compo interactions needed. 
Use case:
When using the ToggleLoadingState interaction for buttons, you want to toggle the loading state off whenever the action is done, not depending on Error of Success. 