### PR TITLE
Add 'when needed' option to data pagination TA-1648

### DIFF
--- a/src/components/dataList.js
+++ b/src/components/dataList.js
@@ -21,7 +21,6 @@
         const {
           take,
           filter,
-          hidePagination,
           type,
           model,
           authProfile,
@@ -30,6 +29,7 @@
           searchProperty,
           order,
           orderBy,
+          pagination,
         } = options;
 
         const rowsPerPage = parseInt(take, 10) || 50;
@@ -44,7 +44,7 @@
         const isPristine = isEmpty && isDev;
         const displayError = showError === 'built-in';
         const listRef = React.createRef();
-
+        const [showPagination, setShowPagination] = useState(true);
         const builderLayout = () => (
           <>
             {searchProperty && !hideSearch && (
@@ -64,7 +64,7 @@
               </div>
             </div>
 
-            {isDev && !hidePagination && (
+            {isDev && showPagination && (
               <div className={classes.footer}>
                 <Pagination
                   totalCount={0}
@@ -183,6 +183,24 @@
           });
 
         useEffect(() => {
+          if (!isDev && data) {
+            switch (pagination) {
+              case 'never':
+                setShowPagination(false);
+                break;
+              case 'whenNeeded':
+                if (rowsPerPage >= data.totalCount) {
+                  setShowPagination(false);
+                }
+                break;
+              default:
+              case 'always':
+                setShowPagination(true);
+            }
+          }
+        }, [data, rowsPerPage]);
+
+        useEffect(() => {
           const handler = setTimeout(() => {
             setSearchTerm(search);
           }, 300);
@@ -267,7 +285,7 @@
                 </div>
               )}
 
-              {!hidePagination && (
+              {showPagination && (
                 <div className={classes.footer}>
                   <Pagination
                     totalCount={totalCount}

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -329,11 +329,20 @@
 
     useEffect(() => {
       if (!isDev && data) {
-        pagination === 'always' && setShowPagination(true);
-        pagination === 'never' && setShowPagination(false);
-        pagination === 'whenNeeded' &&
-          rowsPerPage >= totalCount &&
-          setShowPagination(false);
+        switch (pagination) {
+          case 'never':
+            setShowPagination(false);
+            break;
+          case 'whenNeeded':
+            if (rowsPerPage >= totalCount) {
+              setShowPagination(false);
+            }
+            break;
+          default:
+          case 'always':
+            setShowPagination(true);
+            break;
+        }
       }
     }, [data, rowsPerPage]);
 

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -58,6 +58,7 @@
     const [rowsPerPage, setRowsPerPage] = useState(takeNum);
     const [search, setSearch] = useState('');
     const [searchTerm, setSearchTerm] = useState('');
+    const [showPagination, setShowPagination] = useState(true);
     const searchPropertyArray = [searchProperty].flat();
     const { label: searchPropertyLabel = '{property}' } =
       getProperty(searchProperty) || {};
@@ -134,8 +135,8 @@
       useGetAll(model, {
         rawFilter: where,
         variables,
-        skip: pagination && page * rowsPerPage,
-        take: pagination && rowsPerPage,
+        skip: pagination !== 'never' && page * rowsPerPage,
+        take: pagination !== 'never' && rowsPerPage,
       });
 
     useEffect(() => {
@@ -326,6 +327,16 @@
       return tableContent;
     };
 
+    useEffect(() => {
+      if (!isDev && data) {
+        pagination === 'always' && setShowPagination(true);
+        pagination === 'never' && setShowPagination(false);
+        pagination === 'whenNeeded' &&
+          rowsPerPage >= totalCount &&
+          setShowPagination(false);
+      }
+    }, [data, rowsPerPage]);
+
     return (
       <div className={classes.root}>
         <Paper
@@ -370,7 +381,7 @@
               )}
             </Table>
           </TableContainer>
-          {pagination && (
+          {showPagination && (
             <TablePagination
               classes={{ root: classes.pagination }}
               rowsPerPageOptions={[5, 10, 25, 50, 100]}

--- a/src/prefabs/dataList.js
+++ b/src/prefabs/dataList.js
@@ -68,6 +68,21 @@
           },
         },
         {
+          label: 'Pagination',
+          key: 'pagination',
+          value: 'always',
+          type: 'CUSTOM',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              { name: 'Always', value: 'always' },
+              { name: 'When needed', value: 'whenNeeded' },
+              { name: 'Never', value: 'never' },
+            ],
+          },
+        },
+        {
           value: '5',
           label: 'Rows per page (max 50)',
           key: 'take',

--- a/src/prefabs/dataList.js
+++ b/src/prefabs/dataList.js
@@ -149,12 +149,6 @@
           type: 'SIZES',
         },
         {
-          label: 'Hide pagination',
-          key: 'hidePagination',
-          value: false,
-          type: 'TOGGLE',
-        },
-        {
           value: '',
           label: 'Hide built-in search field',
           key: 'hideSearch',

--- a/src/prefabs/dataTable.js
+++ b/src/prefabs/dataTable.js
@@ -86,10 +86,19 @@
           type: 'FONT',
         },
         {
-          type: 'TOGGLE',
           label: 'Pagination',
           key: 'pagination',
-          value: true,
+          value: 'always',
+          type: 'CUSTOM',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              { name: 'Always', value: 'always' },
+              { name: 'When needed', value: 'whenNeeded' },
+              { name: 'Never', value: 'never' },
+            ],
+          },
         },
         {
           value: '5',
@@ -106,12 +115,6 @@
               { name: '50', value: '50' },
               { name: '100', value: '100' },
             ],
-            condition: {
-              type: 'SHOW',
-              option: 'pagination',
-              comparator: 'EQ',
-              value: true,
-            },
           },
         },
         {
@@ -119,14 +122,6 @@
           label: 'Rows per page text',
           key: 'labelRowsPerPage',
           value: ['Rows per page'],
-          configuration: {
-            condition: {
-              type: 'SHOW',
-              option: 'pagination',
-              comparator: 'EQ',
-              value: true,
-            },
-          },
         },
         {
           type: 'TOGGLE',

--- a/src/prefabs/dataTable.js
+++ b/src/prefabs/dataTable.js
@@ -115,6 +115,12 @@
               { name: '50', value: '50' },
               { name: '100', value: '100' },
             ],
+            condition: {
+              type: 'HIDE',
+              option: 'pagination',
+              comparator: 'EQ',
+              value: 'never',
+            },
           },
         },
         {
@@ -122,6 +128,14 @@
           label: 'Rows per page text',
           key: 'labelRowsPerPage',
           value: ['Rows per page'],
+          configuration: {
+            condition: {
+              type: 'HIDE',
+              option: 'pagination',
+              comparator: 'EQ',
+              value: 'never',
+            },
+          },
         },
         {
           type: 'TOGGLE',


### PR DESCRIPTION
This gives the DataTable and the DataList components an extra 'When needed' option.
This way, the no-coder can decide to only show the pagination information when it's needed.

### Example
A DataTable gets 7 results from a response, and the pagination is set to show 10 records per page, making the pagination unnecessary. If 'when needed' is selected, the pagination would not be shown.
<img width="247" alt="Screen Shot 2020-09-29 at 17 27 08" src="https://user-images.githubusercontent.com/6746411/94579365-0732cc00-0279-11eb-95c5-7e3becdcb06a.png">


Here is the [related Jira ticket](https://bettyblocks.atlassian.net/browse/TA-1648?atlOrigin=eyJpIjoiY2Q4OWEwNjdiZDNmNGIzM2E3OTFmN2NhZDk2ODI5OWUiLCJwIjoiaiJ9).