### PR TITLE
Show correct rows per page selection, even when model is selected.

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -183,6 +183,10 @@
       repeat();
     });
 
+    useEffect(() => {
+      setRowsPerPage(takeNum);
+    }, [takeNum]);
+
     const mounted = useRef(true);
     useEffect(() => {
       if (!mounted.current && loading) {


### PR DESCRIPTION
Previously, **if a model was selected on a dataTable**, and the `rowsPerPage` option was changed, these changes wouldn't show in the pagination section of the component without a page refresh.

With this PR the component now listens for changes made to the `takeNum` and updates the `setRowsPerPage` accordingly, without any refresh of the page needed.
![datatable](https://user-images.githubusercontent.com/6746411/94830010-67597780-040b-11eb-8c20-2b9d585c3062.gif)
