### PR TITLE
add submit after change option

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -28,6 +28,7 @@
       customModelAttribute: customModelAttributeObj,
       property,
       nameAttribute,
+      submit,
     } = options;
     const { Autocomplete } = window.MaterialUI.Lab;
     const {
@@ -184,6 +185,8 @@
       }
     }
 
+    const inputRef = useRef(null);
+
     const onChange = (_, newValue) => {
       if (!valueProp || !newValue) {
         setCurrentValue(newValue);
@@ -196,6 +199,9 @@
       }
       setCurrentValue(newCurrentValue);
       B.triggerEvent('OnChange');
+      if (submit && input.current.form) {
+        inputRef.current.form.dispatchEvent(new Event('submit'));
+      }
     };
 
     const getDefaultValue = records => {

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -14,6 +14,7 @@
       customModelAttribute: customModelAttributeObj,
       validationValueMissing,
       nameAttribute,
+      submit,
     } = options;
     const { useText, getCustomModelAttribute } = B;
     const isDev = B.env === 'dev';
@@ -47,9 +48,14 @@
       setHelper(message);
     };
 
+    const inputRef = useRef(null);
+
     const handleChange = evt => {
       handleValidation(evt.target.checked);
       setChecked(evt.target.checked);
+      if (submit && input.current.form) {
+        inputRef.current.form.dispatchEvent(new Event('submit'));
+      }
     };
 
     useEffect(() => {

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -26,6 +26,7 @@
       property,
       validationValueMissing,
       nameAttribute,
+      submit,
     } = options;
     const isDev = B.env === 'dev';
     const displayError = showError === 'built-in';
@@ -135,12 +136,17 @@
       setHelper(message);
     };
 
+    const inputRef = useRef(null);
+
     const handleChange = evt => {
       if (afterFirstInvalidation) {
         handleValidation();
       }
 
       setValue(getValue(evt.target.value));
+      if (submit && input.current.form) {
+        inputRef.current.form.dispatchEvent(new Event('submit'));
+      }
     };
 
     const validationHandler = () => {

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -25,6 +25,7 @@
       property,
       validationValueMissing,
       nameAttribute,
+      submit,
     } = options;
     const { TextField, MenuItem } = window.MaterialUI.Core;
     const displayError = showError === 'built-in';
@@ -90,6 +91,8 @@
       setHelper(message);
     };
 
+    const inputRef = useRef(null);
+
     const handleChange = event => {
       const {
         target: { value: eventValue },
@@ -100,6 +103,9 @@
       }
 
       setCurrentValue(eventValue);
+      if (submit && input.current.form) {
+        inputRef.current.form.dispatchEvent(new Event('submit'));
+      }
     };
 
     const validationHandler = () => {
@@ -168,6 +174,7 @@
           {renderOptions()}
         </TextField>
         <input
+          ref={input}
           className={classes.validationInput}
           onInvalid={validationHandler}
           type="text"

--- a/src/prefabs/autoComplete.js
+++ b/src/prefabs/autoComplete.js
@@ -232,6 +232,12 @@
         },
         {
           value: false,
+          label: 'Submit after change',
+          key: 'submit',
+          type: 'TOGGLE',
+        },
+        {
+          value: false,
           label: 'Styles',
           key: 'styles',
           type: 'TOGGLE',

--- a/src/prefabs/checkbox.js
+++ b/src/prefabs/checkbox.js
@@ -123,6 +123,12 @@
             },
           },
         },
+        {
+          value: false,
+          label: 'Submit after change',
+          key: 'submit',
+          type: 'TOGGLE',
+        },
       ],
       descendants: [],
     },

--- a/src/prefabs/radio.js
+++ b/src/prefabs/radio.js
@@ -255,6 +255,12 @@
         },
         {
           value: false,
+          label: 'Submit after change',
+          key: 'submit',
+          type: 'TOGGLE',
+        },
+        {
+          value: false,
           label: 'Styles',
           key: 'styles',
           type: 'TOGGLE',

--- a/src/prefabs/select.js
+++ b/src/prefabs/select.js
@@ -263,6 +263,12 @@
         },
         {
           value: false,
+          label: 'Submit after change',
+          key: 'submit',
+          type: 'TOGGLE',
+        },
+        {
+          value: false,
           label: 'Styles',
           key: 'styles',
           type: 'TOGGLE',


### PR DESCRIPTION
This makes inline editing in a dataList or dataTable. Select, Autocomplete, Check box and Radio have a submit after change option that wil trigger it's parent form submit. 