### PR TITLE
fix: make offset dynamic

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -376,7 +376,6 @@
           initialRender.current = false;
         };
 
-        const offset = 500;
         const tableContainerElement = tableContainerRef.current;
         if (loadOnScroll) {
           const parent = tableContainerElement.parentNode;
@@ -385,6 +384,7 @@
           }
           const scrollEvent = e => {
             const { scrollTop, clientHeight, scrollHeight } = e.target;
+            const offset = scrollHeight / 5;
             const hitBottom = scrollTop + clientHeight >= scrollHeight - offset;
             if (hitBottom && !fetchingNextSet.current) {
               fetchNextSet();


### PR DESCRIPTION
Makes `offset` dynamic, making the fetch happen when scroll is 80% through content.