### PR TITLE
fix: dont render invisible components

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -31,12 +31,11 @@
       });
     }, []);
 
-    const AlertPanel = (
+    const AlertPanel = open ? (
       <Alert
         classes={{
           root: classes.root,
         }}
-        className={open || isDev ? '' : classes.hide}
         icon={icon !== 'None' ? React.createElement(Icons[icon]) : null}
         action={
           collapsable ? (
@@ -55,6 +54,8 @@
         {title && <AlertTitle>{title}</AlertTitle>}
         {text || body}
       </Alert>
+    ) : (
+      <></>
     );
     return isDev ? (
       <div className={classes.wrapper}>{AlertPanel}</div>
@@ -100,9 +101,6 @@
           getSpacing(outerSpacing[2]),
         marginLeft: ({ options: { outerSpacing } }) =>
           getSpacing(outerSpacing[3]),
-      },
-      hide: {
-        display: 'none !important',
       },
     };
   },

--- a/src/components/column.js
+++ b/src/components/column.js
@@ -3,19 +3,16 @@
   type: 'LAYOUT_COMPONENT',
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'VERTICAL',
-  jsx: (
-    <div
-      className={[
-        classes.column,
-        options.show || B.env === 'dev' ? '' : classes.hide,
-      ].join(' ')}
-    >
-      {(() => {
-        const isEmpty = children.length === 0;
+  jsx: (() => {
+    const { visible } = options;
+    const { env } = B;
+    const isDev = env === 'dev';
+    const isEmpty = children.length === 0;
+    const isPristine = isEmpty && isDev;
 
-        const isPristine = isEmpty && B.env === 'dev';
-
-        return children.length !== 0 ? (
+    const Column = (
+      <div className={classes.column}>
+        {!isEmpty ? (
           children
         ) : (
           <div
@@ -24,12 +21,16 @@
               isPristine ? classes.pristine : '',
             ].join(' ')}
           >
-            {isPristine ? 'Column' : ''}
+            {isPristine && 'Column'}
           </div>
-        );
-      })()}
-    </div>
-  ),
+        )}
+      </div>
+    );
+
+    const EmptyColumn = isDev ? <div /> : <></>;
+
+    return visible ? Column : EmptyColumn;
+  })(),
   styles: B => theme => {
     const style = new B.Styling(theme);
     const getSpacing = (idx, device = 'Mobile') =>
@@ -281,9 +282,6 @@
         borderColor: '#AFB5C8',
         borderStyle: 'dashed',
         backgroundColor: '#F0F1F5',
-      },
-      hide: {
-        display: 'none !important',
       },
     };
   },

--- a/src/prefabs/1column.js
+++ b/src/prefabs/1column.js
@@ -49,7 +49,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: 'flexible',
               label: 'Column width',

--- a/src/prefabs/2columns.js
+++ b/src/prefabs/2columns.js
@@ -49,7 +49,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '6',
               label: 'Column width',
@@ -223,7 +223,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '6',
               label: 'Column width',

--- a/src/prefabs/3columns.js
+++ b/src/prefabs/3columns.js
@@ -49,7 +49,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '4',
               label: 'Column width',
@@ -223,7 +223,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '4',
               label: 'Column width',
@@ -397,7 +397,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '4',
               label: 'Column width',

--- a/src/prefabs/4columns.js
+++ b/src/prefabs/4columns.js
@@ -49,7 +49,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '3',
               label: 'Column width',
@@ -223,7 +223,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '3',
               label: 'Column width',
@@ -397,7 +397,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '3',
               label: 'Column width',
@@ -571,7 +571,7 @@
         {
           name: 'Column',
           options: [
-            { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+            { type: 'TOGGLE', label: 'Visible', key: 'visible', value: true },
             {
               value: '3',
               label: 'Column width',

--- a/src/prefabs/dialog.js
+++ b/src/prefabs/dialog.js
@@ -154,7 +154,7 @@
                     {
                       type: 'TOGGLE',
                       label: 'Visible',
-                      key: 'show',
+                      key: 'visible',
                       value: true,
                     },
                     {
@@ -2226,7 +2226,7 @@
                             {
                               type: 'TOGGLE',
                               label: 'Visible',
-                              key: 'show',
+                              key: 'visible',
                               value: true,
                             },
                             {

--- a/src/prefabs/panel.js
+++ b/src/prefabs/panel.js
@@ -78,7 +78,12 @@
             {
               name: 'Column',
               options: [
-                { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+                {
+                  type: 'TOGGLE',
+                  label: 'Visible',
+                  key: 'visible',
+                  value: true,
+                },
                 {
                   value: 'flexible',
                   label: 'Column width',

--- a/src/prefabs/paper.js
+++ b/src/prefabs/paper.js
@@ -117,7 +117,12 @@
             {
               name: 'Column',
               options: [
-                { type: 'TOGGLE', label: 'Visible', key: 'show', value: true },
+                {
+                  type: 'TOGGLE',
+                  label: 'Visible',
+                  key: 'visible',
+                  value: true,
+                },
                 {
                   value: 'flexible',
                   label: 'Column width',


### PR DESCRIPTION
This fix will not render invisible components any more. On the canvas it will have to render 1 HTML element for the DND behaviour though.
Also, the key `show` is renamed to `visible` for consistency in our components/prefabs.