### PR TITLE
feat: add overflow to box

### DIFF
--- a/src/components/box.js
+++ b/src/components/box.js
@@ -102,6 +102,7 @@
         bottom: ({ options: { bottom } }) => bottom,
         left: ({ options: { left } }) => left,
         width: ({ options: { width } }) => width,
+        overflow: ({ options: { overflow } }) => overflow,
         '& > div': {
           flexShrink: [1, '!important'],
           flexGrow: [1, '!important'],
@@ -120,6 +121,7 @@
         flexShrink: ({ options: { stretch } }) => (stretch ? 1 : 0),
         flexGrow: ({ options: { stretch } }) => (stretch ? 1 : 0),
         transition: 'opacity 0.5s ease-out',
+        overflow: ({ options: { overflow } }) => overflow,
         marginTop: ({ options: { outerSpacing } }) =>
           getSpacing(outerSpacing[0]),
         marginRight: ({ options: { outerSpacing } }) =>

--- a/src/prefabs/box.js
+++ b/src/prefabs/box.js
@@ -70,6 +70,24 @@
           },
         },
         {
+          value: 'visible',
+          label: 'Overflow',
+          key: 'overflow',
+          type: 'CUSTOM',
+          configuration: {
+            as: 'DROPDOWN',
+            dataType: 'string',
+            allowedInput: [
+              { name: 'Visible', value: 'visible' },
+              { name: 'Hidden', value: 'hidden' },
+              { name: 'Scroll', value: 'scroll' },
+              { name: 'Auto', value: 'auto' },
+              { name: 'Initial', value: 'initial' },
+              { name: 'Inherit', value: 'inherit' },
+            ],
+          },
+        },
+        {
           value: ['0rem', '0rem', '0rem', '0rem'],
           label: 'Outer space',
           key: 'outerSpacing',

--- a/src/prefabs/dialog.js
+++ b/src/prefabs/dialog.js
@@ -377,6 +377,24 @@
                           },
                         },
                         {
+                          value: 'visible',
+                          label: 'Overflow',
+                          key: 'overflow',
+                          type: 'CUSTOM',
+                          configuration: {
+                            as: 'DROPDOWN',
+                            dataType: 'string',
+                            allowedInput: [
+                              { name: 'Visible', value: 'visible' },
+                              { name: 'Hidden', value: 'hidden' },
+                              { name: 'Scroll', value: 'scroll' },
+                              { name: 'Auto', value: 'auto' },
+                              { name: 'Initial', value: 'initial' },
+                              { name: 'Inherit', value: 'inherit' },
+                            ],
+                          },
+                        },
+                        {
                           value: ['0rem', '0rem', '0rem', '0rem'],
                           label: 'Outer space',
                           key: 'outerSpacing',

--- a/src/prefabs/form.js
+++ b/src/prefabs/form.js
@@ -1799,6 +1799,24 @@
               },
             },
             {
+              value: 'visible',
+              label: 'Overflow',
+              key: 'overflow',
+              type: 'CUSTOM',
+              configuration: {
+                as: 'DROPDOWN',
+                dataType: 'string',
+                allowedInput: [
+                  { name: 'Visible', value: 'visible' },
+                  { name: 'Hidden', value: 'hidden' },
+                  { name: 'Scroll', value: 'scroll' },
+                  { name: 'Auto', value: 'auto' },
+                  { name: 'Initial', value: 'initial' },
+                  { name: 'Inherit', value: 'inherit' },
+                ],
+              },
+            },
+            {
               value: ['0rem', '0rem', '0rem', '0rem'],
               label: 'Outer space',
               key: 'outerSpacing',


### PR DESCRIPTION
[Related Jira ticket](https://bettyblocks.atlassian.net/jira/software/projects/TA/boards/73?selectedIssue=TA-1946).
This pr allows you to set the overflow value of a box component.
<img width="275" alt="Screenshot 2020-10-28 at 11 25 07" src="https://user-images.githubusercontent.com/6746411/97423931-4bfd6180-1910-11eb-8bf9-bd37d9a280cb.png">
## Reason
Another way for the streched boxes child (within a grid) to use its parents actual height, besides giving the box a height itself (of 1px/0px), is to give it an overflow value of 'hidden' (explained in more detail [here](https://stackoverflow.com/a/36247448)).