### PR TITLE
fix: autocomplete multiselect labels are selected with default value

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -346,6 +346,7 @@
         options={results}
         defaultValue={getDefaultValue(results)}
         getOptionLabel={renderLabel}
+        getOptionSelected={(option, value) => value.id === option.id}
         PopoverProps={{
           classes: {
             root: classes.popover,


### PR DESCRIPTION
Tested on edge.
Labels (multiselect option) get selected in autocomplete when putting an array like ["a","b"] as a default value.
As well as ID's or anything that aligns with the Property value 