### PR TITLE
fix: use color setting in appbar title when link is set (fixes #649)

### DIFF
--- a/src/components/appBar.js
+++ b/src/components/appBar.js
@@ -120,6 +120,10 @@
       },
       title: {
         textDecoration: 'none',
+        color: ({ options: { color } }) => [
+          style.getColor(color),
+          '!important',
+        ],
       },
       spacer: {
         flexGrow: 1,


### PR DESCRIPTION
Fixes issue #649 