### PR TITLE
fix: remove empty string from properties list

### DIFF
--- a/src/prefabs/dataTable.js
+++ b/src/prefabs/dataTable.js
@@ -16,7 +16,7 @@
     close,
   }) => {
     const [modelId, setModelId] = React.useState('');
-    const [properties, setProperties] = React.useState(['']);
+    const [properties, setProperties] = React.useState([]);
 
     return (
       <>


### PR DESCRIPTION
remove default value of empty string since its no longer required