### PR TITLE
Fix/autocomplete free solo selected record

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -67,6 +67,8 @@
       customModelAttribute || {};
     const { kind, values: listValues } = getProperty(property) || {};
     const [currentValue, setCurrentValue] = useState(useText(defaultValue));
+    const [currentLabel, setCurrentLabel] = useState('');
+
     const labelText = useText(label);
 
     const textFieldProps = {
@@ -216,10 +218,22 @@
     const onChange = (_, newValue) => {
       if (!valueProp || !newValue) {
         setCurrentValue(newValue);
+        setCurrentLabel(newValue);
         B.triggerEvent('OnChange');
         return;
       }
+
       let newCurrentValue = newValue[valueProp.name] || newValue;
+
+      if (typeof newValue === 'string') {
+        if (currentLabel === newValue) {
+          newCurrentValue = currentValue;
+        }
+      } else if (searchProp) {
+        const newLabelValue = newValue[searchProp.name];
+        setCurrentLabel(newLabelValue);
+      }
+
       if (multiple) {
         newCurrentValue = newValue.map(rec => rec[valueProp.name] || rec);
       }
@@ -227,7 +241,8 @@
       B.triggerEvent('OnChange');
     };
 
-    const getDefaultValue = records => {
+    const getDefaultValue = React.useCallback(() => {
+      if (!results) return;
       if (!currentValue) {
         return multiple ? [] : null;
       }
@@ -237,7 +252,7 @@
           ? currentValue.toString().split(',')
           : [currentValue];
       }
-      const currentRecords = records.reduce((acc, cv) => {
+      const currentRecords = results.reduce((acc, cv) => {
         const searchStr = cv[valueProp.name].toString();
         const search = cv[valueProp.name];
         if (
@@ -251,7 +266,14 @@
 
       const singleRecord = currentRecords[0] ? { ...currentRecords[0] } : null;
       return multiple ? currentRecords : singleRecord;
-    };
+    }, [results]);
+
+    const defaultRecord = getDefaultValue();
+    useEffect(() => {
+      if (!multiple && defaultRecord && searchProp) {
+        setCurrentLabel(defaultRecord[searchProp.name]);
+      }
+    }, [defaultRecord]);
 
     const renderLabel = option => {
       const optionLabel = option[searchProp.name];
@@ -360,7 +382,7 @@
         freeSolo={freeSolo}
         autoSelect={freeSolo}
         options={results}
-        defaultValue={getDefaultValue(results)}
+        defaultValue={defaultRecord}
         getOptionLabel={renderLabel}
         getOptionSelected={(option, value) => value.id === option.id}
         PopoverProps={{

--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -242,8 +242,7 @@
     };
 
     const getDefaultValue = React.useCallback(() => {
-      if (!results) return;
-      if (!currentValue) {
+      if (!currentValue || !results) {
         return multiple ? [] : null;
       }
       let currentRecordsKeys = currentValue;


### PR DESCRIPTION
When you have free solo on the auto complete and blur on an existing record it would set the value of the hidden field to the text label instead of the id value of the selected record. This change fixes that behaviour by comparing the search value with the label value of the selected record