### PR TITLE
fix: added height to tabs and tab component

### DIFF
--- a/src/components/tab.js
+++ b/src/components/tab.js
@@ -39,6 +39,7 @@
         role="tabpanel"
         hidden={!isActive}
         aria-labelledby="tabs"
+        classes={{ root: classes.root }}
       >
         {children.length === 0 ? <EmptyBox /> : children}
       </Typography>
@@ -90,9 +91,15 @@
       disableRipple,
     ]);
 
-    return isDev ? <div>{TabPanel}</div> : TabPanel;
+    return isDev ? <div className={classes.wrapper}>{TabPanel}</div> : TabPanel;
   })(),
   styles: () => () => ({
+    wrapper: {
+      height: ({ options: { height } }) => height,
+    },
+    root: {
+      height: ({ options: { height } }) => height,
+    },
     empty: {
       display: 'flex',
       alignItems: 'center',

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -16,6 +16,7 @@
       showAllTabs,
       hideTabs,
     } = options;
+
     const orientation =
       alignment === 'top' || alignment === 'bottom' ? 'horizontal' : 'vertical';
     const isDev = env === 'dev';
@@ -131,12 +132,14 @@
     const style = new B.Styling(t);
     return {
       wrapper: {
+        height: ({ options: { height } }) => height,
         '& .MuiTabs-flexContainer > button': {
           pointerEvents: 'none',
         },
       },
       tabs: {
         display: 'flex',
+        height: ({ options: { height } }) => height,
         flexDirection: ({ options: { alignment } }) => {
           switch (alignment) {
             case 'top':

--- a/src/prefabs/tab.js
+++ b/src/prefabs/tab.js
@@ -13,6 +13,15 @@
           type: 'VARIABLE',
         },
         {
+          type: 'SIZE',
+          label: 'Height',
+          key: 'height',
+          value: '',
+          configuration: {
+            as: 'UNIT',
+          },
+        },
+        {
           label: 'Icon',
           key: 'icon',
           value: 'None',

--- a/src/prefabs/tabs.js
+++ b/src/prefabs/tabs.js
@@ -19,6 +19,15 @@
           type: 'TOGGLE',
         },
         {
+          type: 'SIZE',
+          label: 'Height',
+          key: 'height',
+          value: '',
+          configuration: {
+            as: 'UNIT',
+          },
+        },
+        {
           value: 'top',
           label: 'Alignment',
           key: 'alignment',


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where tabs and tab component cannot be set to stretch full height of their parent

### Where should the reviewer start?

/src/components/tabs
/src/prefabs/tabs
/src/components/tab
/src/prefabs/tab

### How should this be manually tested?

Add to a drawer one tabs component set height to 100%, add a tab component inside the tabs and set it's height to 100% add a box inside the tab and set it's height to 100% the box and the tabs should be full height of the drawer.

### Are there points in the code the reviewer needs to double check?

Potential side-effects introduced by this behaviour

### What are the relevant issues?

Resolves WORK-8