### PR TITLE
Revert "fix: onRowClick has no event object"

### DIFF
--- a/src/components/dataTableColumn.js
+++ b/src/components/dataTableColumn.js
@@ -109,9 +109,7 @@
       <TableCell
         classes={{ root: classes.root }}
         align={horizontalAlignment}
-        onClick={event =>
-          handleRowClick && handleRowClick(myEndpoint || event, context)
-        }
+        onClick={() => handleRowClick && handleRowClick(myEndpoint, context)}
       >
         {headerOnly ? Header : Content}
       </TableCell>


### PR DESCRIPTION
Reverts bettyblocks/material-ui-component-set#714

We have a better fix in the compiler. So this solution is no longer required