### PR TITLE
Fix/media variable placeholder work 115

### DIFF
--- a/src/components/media.js
+++ b/src/components/media.js
@@ -111,7 +111,7 @@
         className={[
           classes.outerSpacing,
           isDev ? classes.devWrapper : '',
-          !isEmpty ? classes.hasContent : '',
+          !isEmpty && !variable ? classes.hasContent : '',
         ].join(' ')}
       >
         <MediaComponent />


### PR DESCRIPTION
Fixes the text displayed when a variable is selected as an image source
Image shows how it was previously and current solution.
<img width="1214" alt="Screenshot 2021-01-05 at 09 55 12" src="https://user-images.githubusercontent.com/6746411/103626524-9a486580-4f3c-11eb-8d26-e35bb7240a77.png">
