### PR TITLE
Feat/preview uploaded image work 42

### DIFF
--- a/src/components/box.js
+++ b/src/components/box.js
@@ -25,26 +25,10 @@
     const opac = transparent ? 0 : 1;
     const [opacity, setOpacity] = useState(opac);
     const [interactionBackground, setInteractionBackground] = useState('');
-    const [boxStyles, setBoxStyles] = useState({});
 
     B.defineFunction('setBackgroundImage', url => {
       setInteractionBackground(url);
     });
-
-    useEffect(() => {
-      setBoxStyles({ opacity });
-    }, []);
-
-    useEffect(() => {
-      if (interactionBackground) {
-        setBoxStyles({
-          backgroundImage: interactionBackground
-            ? `url("${interactionBackground}")`
-            : 'none',
-          opacity,
-        });
-      }
-    }, [interactionBackground]);
 
     const boxOptions = {
       display: isFlex && 'flex',
@@ -78,7 +62,12 @@
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        style={boxStyles}
+        style={{
+          backgroundImage: interactionBackground
+            ? `url("${interactionBackground}")`
+            : 'auto',
+          opacity,
+        }}
       >
         {isEmpty ? 'Box' : children}
       </Box>

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -24,6 +24,27 @@
     const isFlex = alignment !== 'none' || valignment !== 'none';
     const opac = transparent ? 0 : 1;
     const [opacity, setOpacity] = useState(opac);
+    const [interactionBackground, setInteractionBackground] = useState('');
+    const [boxStyles, setBoxStyles] = useState({});
+
+    B.defineFunction('setBackgroundImage', url => {
+      setInteractionBackground(url);
+    });
+
+    useEffect(() => {
+      setBoxStyles({ opacity });
+    }, []);
+
+    useEffect(() => {
+      if (interactionBackground) {
+        setBoxStyles({
+          backgroundImage: interactionBackground
+            ? `url("${interactionBackground}")`
+            : 'none',
+          opacity,
+        });
+      }
+    }, [interactionBackground]);
 
     const boxOptions = {
       display: isFlex && 'flex',
@@ -57,7 +78,7 @@
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        style={{ opacity }}
+        style={boxStyles}
       >
         {isEmpty ? 'Box' : children}
       </Box>

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -199,7 +199,11 @@
         <IconButton
           size="small"
           className={classes.remove}
-          onClick={file ? () => removeFileFromList(file.url) : {}}
+          onClick={() => {
+            if (file) {
+              removeFileFromList(file.url);
+            }
+          }}
         >
           <Delete className={classes.deleteIcon} fontSize="small" />
         </IconButton>
@@ -226,17 +230,15 @@
       switch (type) {
         case 'grid':
           return (
-            <>
-              <div className={classes.gridView}>
-                <div className={classes.gridItem}>
-                  {showImagePreview && <div className={classes.gridDevImage} />}
-                  <div className={classes.gridItemDetails}>
-                    <FileDetails />
-                    <DeleteButton />
-                  </div>
+            <div className={classes.gridView}>
+              <div className={classes.gridItem}>
+                {showImagePreview && <div className={classes.gridDevImage} />}
+                <div className={classes.gridItemDetails}>
+                  <FileDetails />
+                  <DeleteButton />
                 </div>
               </div>
-            </>
+            </div>
           );
         case 'list':
         default:
@@ -267,28 +269,26 @@
       switch (type) {
         case 'grid':
           return (
-            <>
-              <div className={classes.gridView}>
-                <div className={classes.gridItem}>
-                  {showImagePreview && (
-                    <div
-                      style={{
-                        backgroundImage: `url("${file.url}")`,
-                      }}
-                      className={classes.gridImage}
-                    />
-                  )}
-                  <div className={classes.gridItemDetails}>
-                    <FileDetails
-                      file={file}
-                      fileType={uploadedFile.type}
-                      fileSize={uploadedFile.size}
-                    />
-                    <DeleteButton file={file} />
-                  </div>
+            <div className={classes.gridView}>
+              <div className={classes.gridItem}>
+                {showImagePreview && (
+                  <div
+                    style={{
+                      backgroundImage: `url("${file.url}")`,
+                    }}
+                    className={classes.gridImage}
+                  />
+                )}
+                <div className={classes.gridItemDetails}>
+                  <FileDetails
+                    file={file}
+                    fileType={uploadedFile.type}
+                    fileSize={uploadedFile.size}
+                  />
+                  <DeleteButton file={file} />
                 </div>
               </div>
-            </>
+            </div>
           );
         case 'list':
         default:
@@ -322,20 +322,18 @@
       switch (type) {
         case 'grid':
           return (
-            <>
-              <div className={classes.gridView}>
-                <div className={classes.gridItem}>
-                  {showImagePreview && (
-                    <div className={classes.gridUploadingImage}>
-                      <CloudUpload />
-                    </div>
-                  )}
-                  <div className={classes.gridItemDetails}>
-                    <span>Uploading</span>
+            <div className={classes.gridView}>
+              <div className={classes.gridItem}>
+                {showImagePreview && (
+                  <div className={classes.gridUploadingImage}>
+                    <CloudUpload />
                   </div>
+                )}
+                <div className={classes.gridItemDetails}>
+                  <span>Uploading</span>
                 </div>
               </div>
-            </>
+            </div>
           );
         case 'list':
         default:
@@ -357,7 +355,7 @@
       }
     };
 
-    const Control = (
+    const Control = () => (
       <FormControl
         fullWidth={fullWidth}
         required={required}
@@ -376,7 +374,6 @@
         <FormHelperText classes={{ root: classes.helper }}>
           {helperValue}
         </FormHelperText>
-        {loading && B.triggerEvent('onLoad')}
         <div className={classes.messageContainer}>
           {data &&
             data.length > 0 &&
@@ -385,6 +382,12 @@
         </div>
       </FormControl>
     );
+
+    useEffect(() => {
+      if (loading) {
+        B.triggerEvent('onLoad');
+      }
+    }, [loading]);
 
     useEffect(() => {
       if (files.length > 0) {
@@ -396,11 +399,13 @@
 
     return isDev ? (
       <div>
-        <div className={classes.root}>{Control}</div>
+        <div className={classes.root}>
+          <Control />
+        </div>
         <DevUploadedFile />
       </div>
     ) : (
-      Control
+      <Control />
     );
   })(),
   styles: B => t => {
@@ -413,9 +418,9 @@
           fullWidth ? 'block' : 'inline-block',
       },
       label: {
-        marginLeft: [0, '!important'],
+        marginLeft: '0!important',
         pointerEvents: B.env === 'dev' && 'none',
-        alignItems: ['start', '!important'],
+        alignItems: 'start!important',
         color: ({ options: { labelColor } }) => [
           style.getColor(labelColor),
           '!important',
@@ -458,7 +463,7 @@
         flex: 1,
         textAlign: 'start',
         marginBottom: '0.1875rem!important',
-        marginRight: ['1rem', '!important'],
+        marginRight: '1rem!important',
       },
       button: {
         color: ({ options: { variant, buttonTextColor, background } }) => [
@@ -508,28 +513,28 @@
       },
       gridItem: {
         display: 'flex',
-        borderRadius: '0.3rem',
+        borderRadius: '0.3125rem',
         flexDirection: 'column',
-        border: '1px solid #eee',
-        marginRight: '0.9375rem',
-        marginBottom: '0.9375rem',
+        border: ' 0.0625rem solid #eee',
+        marginRight: '1rem',
+        marginBottom: '1rem',
       },
       gridItemDetails: {
         maxWidth: ({ options: { imagePreviewWidth, showImagePreview } }) =>
           showImagePreview ? imagePreviewWidth : 'auto',
         display: 'flex',
-        margin: '0.9375rem',
+        margin: '1rem',
         justifyContent: 'space-between',
       },
       devImage: {
         display: 'flex',
         overflow: 'hidden',
-        margin: '0.9375rem',
+        margin: '1rem',
         borderStyle: 'dashed',
         borderColor: '#AFB5C8',
-        borderRadius: '0.3rem',
+        borderRadius: '0.3125rem',
         borderWidth: '0.0625rem',
-        border: '2px dashed black',
+        border: '0.125rem dashed black',
         backgroundColor: '#F0F1F5',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
@@ -538,7 +543,7 @@
         extend: 'devImage',
 
         margin: 0,
-        borderRadius: '0.3rem 0.3rem 0 0',
+        borderRadius: '0.3125rem 0.3125rem 0 0',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
@@ -550,9 +555,9 @@
         color: 'white',
         display: 'flex',
         overflow: 'hidden',
-        margin: '0.9375rem',
+        margin: '1rem',
         alignItems: 'center',
-        borderRadius: '0.3rem',
+        borderRadius: '0.3125rem',
         justifyContent: 'center',
         backgroundColor: t.colors.warning,
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
@@ -562,14 +567,14 @@
         extend: 'uploadingImage',
 
         margin: 0,
-        borderRadius: '0.3rem 0.3rem 0 0',
+        borderRadius: '0.3125rem 0.3125rem 0 0',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
       image: {
         overflow: 'hidden',
-        margin: '0.9375rem',
-        borderRadius: '0.3rem',
+        margin: '1rem',
+        borderRadius: '0.3125rem',
         backgroundSize: 'cover',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
@@ -578,7 +583,7 @@
         margin: 0,
         overflow: 'hidden',
         backgroundSize: 'cover',
-        borderRadius: '0.3rem 0.3rem 0 0',
+        borderRadius: '0.3125rem 0.3125rem 0 0',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
@@ -588,7 +593,7 @@
           options: { type, imagePreviewWidth, showImagePreview },
         }) =>
           showImagePreview && type === 'grid'
-            ? `calc(${imagePreviewWidth} - 58px)`
+            ? `${parseInt(imagePreviewWidth, 10) - 58}px`
             : 'auto',
         display: 'flex',
         flexDirection: 'column',
@@ -605,9 +610,9 @@
         width: '0.1875rem',
         height: '0.1875rem',
         borderRadius: '50%',
-        marginLeft: '0.9375rem',
+        marginLeft: '1rem',
         backgroundColor: t.colors.light,
-        marginRight: '0.9375rem',
+        marginRight: '1rem',
       },
       hr: {
         height: 1,
@@ -616,7 +621,7 @@
         backgroundColor: t.colors.light,
       },
       deleteButtonWrapper: {
-        margin: ({ options: { type } }) => (type === 'grid' ? 0 : '0.9375rem'),
+        margin: ({ options: { type } }) => (type === 'grid' ? 0 : '1rem'),
       },
       remove: {
         height: '1.875rem',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -31,8 +31,8 @@
       hideLabel,
       customModelAttribute: customModelAttributeObj,
       nameAttribute,
-      showImagePreview,
       type,
+      showImagePreview,
     } = options;
 
     const isDev = env === 'dev';
@@ -224,21 +224,7 @@
 
     const DevUploadedFile = () => {
       switch (type) {
-        case 'list':
-          return (
-            <>
-              <Hr />
-              <div className={classes.listView}>
-                <div className={classes.fileDetailList}>
-                  {showImagePreview && <div className={classes.devImage} />}
-                  <FileDetails />
-                </div>
-                <DeleteButton />
-              </div>
-            </>
-          );
         case 'grid':
-        default:
           return (
             <>
               <div className={classes.gridView}>
@@ -252,6 +238,20 @@
               </div>
             </>
           );
+        case 'list':
+        default:
+          return (
+            <>
+              <Hr />
+              <div className={classes.listView}>
+                <div className={classes.fileDetailList}>
+                  {showImagePreview && <div className={classes.devImage} />}
+                  <FileDetails />
+                </div>
+                <DeleteButton />
+              </div>
+            </>
+          );
       }
     };
 
@@ -261,32 +261,7 @@
       );
 
       switch (type) {
-        case 'list':
-          return (
-            <>
-              <Hr />
-              <div className={classes.listView}>
-                <div className={classes.fileDetailList}>
-                  {showImagePreview && (
-                    <div
-                      style={{
-                        backgroundImage: `url("${file.url}")`,
-                      }}
-                      className={classes.image}
-                    />
-                  )}
-                  <FileDetails
-                    file={file}
-                    fileType={uploadedFile.type}
-                    fileSize={uploadedFile.size}
-                  />
-                </div>
-                <DeleteButton file={file} />
-              </div>
-            </>
-          );
         case 'grid':
-        default:
           return (
             <>
               <div className={classes.gridView}>
@@ -311,29 +286,37 @@
               </div>
             </>
           );
+        case 'list':
+        default:
+          return (
+            <>
+              <Hr />
+              <div className={classes.listView}>
+                <div className={classes.fileDetailList}>
+                  {showImagePreview && (
+                    <div
+                      style={{
+                        backgroundImage: `url("${file.url}")`,
+                      }}
+                      className={classes.image}
+                    />
+                  )}
+                  <FileDetails
+                    file={file}
+                    fileType={uploadedFile.type}
+                    fileSize={uploadedFile.size}
+                  />
+                </div>
+                <DeleteButton file={file} />
+              </div>
+            </>
+          );
       }
     };
 
     const UploadingFile = () => {
       switch (type) {
-        case 'list':
-          return (
-            <>
-              <Hr />
-              <div className={classes.listView}>
-                {showImagePreview && (
-                  <div className={classes.uploadingImage}>
-                    <CloudUpload />
-                  </div>
-                )}
-                <div className={classes.fileDetails}>
-                  <span>Uploading</span>
-                </div>
-              </div>
-            </>
-          );
         case 'grid':
-        default:
           return (
             <>
               <div className={classes.gridView}>
@@ -346,6 +329,23 @@
                   <div className={classes.gridItemDetails}>
                     <span>Uploading</span>
                   </div>
+                </div>
+              </div>
+            </>
+          );
+        case 'list':
+        default:
+          return (
+            <>
+              <Hr />
+              <div className={classes.listView}>
+                {showImagePreview && (
+                  <div className={classes.uploadingImage}>
+                    <CloudUpload />
+                  </div>
+                )}
+                <div className={classes.fileDetails}>
+                  <span>Uploading</span>
                 </div>
               </div>
             </>
@@ -482,7 +482,7 @@
         flexWrap: 'wrap',
         paddingTop: '1.25rem',
         display: ({ options: { type } }) =>
-          type === 'list' ? 'block' : 'flex',
+          type === 'grid' ? 'flex' : 'block',
         color: ({ options: { textColor } }) => [
           style.getColor(textColor),
           '!important',
@@ -612,7 +612,7 @@
         backgroundColor: t.colors.light,
       },
       deleteButtonWrapper: {
-        margin: ({ options: { type } }) => (type === 'list' ? '0.9375rem' : 0),
+        margin: ({ options: { type } }) => (type === 'grid' ? 0 : '0.9375rem'),
       },
       remove: {
         height: '1.875rem',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -202,6 +202,9 @@
           onClick={() => {
             if (file) {
               removeFileFromList(file.url);
+              if (!multiple) {
+                B.triggerEvent('onFileRemove');
+              }
             }
           }}
         >

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -221,45 +221,105 @@
           );
         case 'grid':
         default:
-          return <>grid</>;
+          return (
+            <>
+              <div className={classes.gridView}>
+                <div className={classes.gridItem}>
+                  {showImagePreview && <div className={classes.devImageGrid} />}
+                  <div className={classes.gridItemDetails}>
+                    <FileDetails />
+                    <DeleteButton />
+                  </div>
+                </div>
+              </div>
+            </>
+          );
       }
     };
 
-    const UploadedFile = ({ file }) => (
-      <>
-        <Hr />
-        <div className={classes.fileList}>
-          {showImagePreview && (
-            <div
-              style={{
-                backgroundImage: `url("${file.url}")`,
-              }}
-              className={classes.image}
-            />
-          )}
-          <FileDetails file={file} />
-          <DeleteButton file={file} />
-        </div>
-      </>
-    );
+    const UploadedFile = ({ file }) => {
+      switch (type) {
+        case 'list':
+          return (
+            <>
+              <Hr />
+              <div className={classes.fileList}>
+                {showImagePreview && (
+                  <div
+                    style={{
+                      backgroundImage: `url("${file.url}")`,
+                    }}
+                    className={classes.image}
+                  />
+                )}
+                <FileDetails file={file} />
+                <DeleteButton file={file} />
+              </div>
+            </>
+          );
+        case 'grid':
+        default:
+          return (
+            <>
+              <div className={classes.gridView}>
+                <div className={classes.gridItem}>
+                  {showImagePreview && (
+                    <div
+                      style={{
+                        backgroundImage: `url("${file.url}")`,
+                      }}
+                      className={classes.imageGrid}
+                    />
+                  )}
+                  <div className={classes.gridItemDetails}>
+                    <FileDetails file={file} />
+                    <DeleteButton file={file} />
+                  </div>
+                </div>
+              </div>
+            </>
+          );
+      }
+    };
 
-    const UploadingFile = () => (
-      <>
-        <Hr />
-        <div className={classes.fileList}>
-          {showImagePreview && (
-            <div className={classes.placeholderImage}>
-              <CloudUpload />
-            </div>
-          )}
-          <div className={classes.fileDetails}>
-            <Typography variant="body1" noWrap className={classes.span}>
-              Uploading
-            </Typography>
-          </div>
-        </div>
-      </>
-    );
+    const UploadingFile = () => {
+      switch (type) {
+        case 'list':
+          return (
+            <>
+              <Hr />
+              <div className={classes.fileList}>
+                {showImagePreview && (
+                  <div className={classes.uploadingImage}>
+                    <CloudUpload />
+                  </div>
+                )}
+                <div className={classes.fileDetails}>
+                  <span>Uploading</span>
+                </div>
+              </div>
+            </>
+          );
+        case 'grid':
+        default:
+          return (
+            <>
+              <div className={classes.gridView}>
+                <div className={classes.gridItem}>
+                  {showImagePreview && (
+                    <div className={classes.uploadingImageGrid}>
+                      <CloudUpload />
+                    </div>
+                  )}
+                  <div className={classes.gridItemDetails}>
+                    <span>Uploading</span>
+                  </div>
+                </div>
+              </div>
+            </>
+          );
+      }
+    };
 
     const Control = (
       <FormControl
@@ -387,7 +447,10 @@
         ],
       },
       messageContainer: {
+        flexWrap: 'wrap',
         paddingTop: '1.25rem',
+        display: ({ options: { type } }) =>
+          type === 'list' ? 'block' : 'flex',
         color: ({ options: { textColor } }) => [
           style.getColor(textColor),
           '!important',
@@ -403,6 +466,22 @@
         display: 'flex',
         alignItems: 'center',
       },
+      gridView: {
+        display: 'flex',
+      },
+      gridItem: {
+        display: 'flex',
+        borderRadius: '0.3rem',
+        flexDirection: 'column',
+        border: '1px solid #eee',
+        marginRight: '0.9375rem',
+        marginBottom: '0.9375rem',
+      },
+      gridItemDetails: {
+        display: 'flex',
+        margin: '0.9375rem',
+        justifyContent: 'space-between',
+      },
       devImage: {
         display: 'flex',
         overflow: 'hidden',
@@ -411,15 +490,24 @@
         borderColor: '#AFB5C8',
         borderRadius: '0.3rem',
         borderWidth: '0.0625rem',
-        backgroundColor: '#F0F1F5',
         border: '2px dashed black',
+        backgroundColor: '#F0F1F5',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
+      },
+      devImageGrid: {
+        extend: 'devImage',
+
+        margin: 0,
+        borderRadius: '0.3rem 0.3rem 0 0',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
       deleteIcon: {
         color: `${t.colors.light}!important`,
       },
-      placeholderImage: {
+      uploadingImage: {
+        border: 'none',
         color: 'white',
         display: 'flex',
         overflow: 'hidden',
@@ -431,6 +519,14 @@
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
+      uploadingImageGrid: {
+        extend: 'uploadingImage',
+
+        margin: 0,
+        borderRadius: '0.3rem 0.3rem 0 0',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
+      },
       image: {
         overflow: 'hidden',
         margin: '0.9375rem',
@@ -438,7 +534,14 @@
         backgroundSize: 'cover',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
-        backgroundImage: 'url("")',
+      },
+      imageGrid: {
+        margin: 0,
+        overflow: 'hidden',
+        backgroundSize: 'cover',
+        borderRadius: '0.3rem 0.3rem 0 0',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
       fileDetails: {
         flexGrow: 1,
@@ -457,9 +560,9 @@
         width: '0.1875rem',
         height: '0.1875rem',
         borderRadius: '50%',
-        marginLeft: '0.625rem',
+        marginLeft: '0.9375rem',
         backgroundColor: t.colors.light,
-        marginRight: '0.625rem',
+        marginRight: '0.9375rem',
       },
       hr: {
         height: 1,
@@ -468,7 +571,7 @@
         backgroundColor: t.colors.light,
       },
       remove: {
-        margin: '0.9375rem!important',
+        height: '1.875rem',
         padding: '0.25rem!important',
       },
     };

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -195,7 +195,7 @@
     const Hr = () => <hr className={classes.hr} />;
 
     const DeleteButton = ({ file }) => (
-      <div className={classes.DeleteButtonWrapper}>
+      <div className={classes.deleteButtonWrapper}>
         <IconButton
           size="small"
           className={classes.remove}
@@ -611,7 +611,7 @@
         border: 'none',
         backgroundColor: t.colors.light,
       },
-      DeleteButtonWrapper: {
+      deleteButtonWrapper: {
         margin: ({ options: { type } }) => (type === 'list' ? '0.9375rem' : 0),
       },
       remove: {

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -184,32 +184,27 @@
 
     const Hr = () => <hr className={classes.hr} />;
 
-    const DeleteButton = ({ file }) => {
-      return (
-        <IconButton
-          size="small"
-          className={classes.remove}
-          onClick={file ? () => removeFileFromList(file.url) : {}}
-        >
-          <Delete fontSize="small" />
-        </IconButton>
-      );
-    };
-
-    const FileDetails = ({ file }) => {
-      return (
-        <div className={classes.fileDetails}>
-          <Typography variant="body1" noWrap className={classes.span}>
-            {file ? file.name : 'File name'}
-          </Typography>
-          <div className={classes.fileDetailList}>
-            <p className={classes.fileDetail}>Size</p>
-            <div className={classes.divider} />
-            <p className={classes.fileDetail}>Type</p>
-          </div>
+    const DeleteButton = ({ file }) => (
+      <IconButton
+        size="small"
+        className={classes.remove}
+        onClick={file ? () => removeFileFromList(file.url) : {}}
+      >
+        <Delete className={classes.deleteIcon} fontSize="small" />
+      </IconButton>
+    );
+    const FileDetails = ({ file }) => (
+      <div className={classes.fileDetails}>
+        <Typography variant="body1" noWrap className={classes.span}>
+          {file ? file.name : 'File name'}
+        </Typography>
+        <div className={classes.fileDetailList}>
+          <p className={classes.fileDetail}>Size</p>
+          <div className={classes.divider} />
+          <p className={classes.fileDetail}>Type</p>
         </div>
-      );
-    };
+      </div>
+    );
 
     const DevUploadedFile = () => {
       switch (type) {
@@ -230,25 +225,23 @@
       }
     };
 
-    const UploadedFile = ({ file }) => {
-      return (
-        <>
-          <Hr />
-          <div className={classes.fileList}>
-            {showImagePreview && (
-              <div
-                style={{
-                  backgroundImage: `url("${file.url}")`,
-                }}
-                className={classes.image}
-              />
-            )}
-            <FileDetails file={file} />
-            <DeleteButton file={file} />
-          </div>
-        </>
-      );
-    };
+    const UploadedFile = ({ file }) => (
+      <>
+        <Hr />
+        <div className={classes.fileList}>
+          {showImagePreview && (
+            <div
+              style={{
+                backgroundImage: `url("${file.url}")`,
+              }}
+              className={classes.image}
+            />
+          )}
+          <FileDetails file={file} />
+          <DeleteButton file={file} />
+        </div>
+      </>
+    );
 
     const UploadingFile = () => (
       <>
@@ -368,6 +361,7 @@
       span: {
         flex: 1,
         textAlign: 'start',
+        marginBottom: '0.1875rem!important',
         marginRight: ['1rem', '!important'],
       },
       button: {
@@ -422,15 +416,18 @@
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
+      deleteIcon: {
+        color: `${t.colors.light}!important`,
+      },
       placeholderImage: {
         color: 'white',
         display: 'flex',
         overflow: 'hidden',
         margin: '0.9375rem',
         alignItems: 'center',
-        backgroundColor: 'red',
         borderRadius: '0.3rem',
         justifyContent: 'center',
+        backgroundColor: t.colors.warning,
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
@@ -450,7 +447,7 @@
       },
       fileDetail: {
         margin: 0,
-        color: 'red',
+        color: t.colors.medium,
       },
       fileDetailList: {
         display: 'flex',
@@ -461,14 +458,14 @@
         height: '0.1875rem',
         borderRadius: '50%',
         marginLeft: '0.625rem',
-        backgroundColor: 'red',
+        backgroundColor: t.colors.light,
         marginRight: '0.625rem',
       },
       hr: {
         height: 1,
         margin: 0,
         border: 'none',
-        backgroundColor: 'red',
+        backgroundColor: t.colors.light,
       },
       remove: {
         margin: '0.9375rem!important',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -32,6 +32,7 @@
       customModelAttribute: customModelAttributeObj,
       nameAttribute,
       showImagePreview,
+      type,
     } = options;
 
     const isDev = env === 'dev';
@@ -181,6 +182,92 @@
       </div>
     );
 
+    const Hr = () => <hr className={classes.hr} />;
+
+    const DeleteButton = ({ file }) => {
+      return (
+        <IconButton
+          size="small"
+          className={classes.remove}
+          onClick={file ? () => removeFileFromList(file.url) : {}}
+        >
+          <Delete fontSize="small" />
+        </IconButton>
+      );
+    };
+
+    const FileDetails = ({ file }) => {
+      return (
+        <div className={classes.fileDetails}>
+          <Typography variant="body1" noWrap className={classes.span}>
+            {file ? file.name : 'File name'}
+          </Typography>
+          <div className={classes.fileDetailList}>
+            <p className={classes.fileDetail}>Size</p>
+            <div className={classes.divider} />
+            <p className={classes.fileDetail}>Type</p>
+          </div>
+        </div>
+      );
+    };
+
+    const DevUploadedFile = () => {
+      switch (type) {
+        case 'list':
+          return (
+            <>
+              <Hr />
+              <div className={classes.fileList}>
+                {showImagePreview && <div className={classes.devImage} />}
+                <FileDetails />
+                <DeleteButton />
+              </div>
+            </>
+          );
+        case 'grid':
+        default:
+          return <>grid</>;
+      }
+    };
+
+    const UploadedFile = ({ file }) => {
+      return (
+        <>
+          <Hr />
+          <div className={classes.fileList}>
+            {showImagePreview && (
+              <div
+                style={{
+                  backgroundImage: `url("${file.url}")`,
+                }}
+                className={classes.image}
+              />
+            )}
+            <FileDetails file={file} />
+            <DeleteButton file={file} />
+          </div>
+        </>
+      );
+    };
+
+    const UploadingFile = () => (
+      <>
+        <Hr />
+        <div className={classes.fileList}>
+          {showImagePreview && (
+            <div className={classes.placeholderImage}>
+              <CloudUpload />
+            </div>
+          )}
+          <div className={classes.fileDetails}>
+            <Typography variant="body1" noWrap className={classes.span}>
+              Uploading
+            </Typography>
+          </div>
+        </div>
+      </>
+    );
+
     const Control = (
       <FormControl
         fullWidth={fullWidth}
@@ -201,57 +288,12 @@
           {helperValue}
         </FormHelperText>
         {loading && B.triggerEvent('onLoad')}
-        {data && data.length > 0 && (
-          <div className={classes.messageContainer}>
-            {data.map(file => (
-              <>
-                <hr className={classes.hr} />
-                <div className={classes.fileList}>
-                  {showImagePreview && <div className={classes.image} />}
-                  <div className={classes.fileDetails}>
-                    <Typography variant="body1" noWrap className={classes.span}>
-                      {file.name}
-                    </Typography>
-                    <div className={classes.fileDetailList}>
-                      <p className={classes.fileDetail}>size</p>
-                      <div className={classes.divider} />
-                      <p className={classes.fileDetail}>type</p>
-                    </div>
-                  </div>
-                  <IconButton
-                    size="small"
-                    className={classes.remove}
-                    onClick={() => removeFileFromList(file.url)}
-                  >
-                    <Delete fontSize="small" />
-                  </IconButton>
-                </div>
-              </>
-            ))}
-          </div>
-        )}
-        {loading && (
-          <div style={{ paddingTop: files.length === 0 ? '0' : '1.25rem' }}>
-            <hr className={classes.hr} />
-            <div className={classes.fileList}>
-              {showImagePreview && (
-                <div className={classes.placeholderImage}>
-                  <CloudUpload />
-                </div>
-              )}
-              <div className={classes.fileDetails}>
-                <Typography variant="body1" noWrap className={classes.span}>
-                  uploading
-                </Typography>
-                <div className={classes.fileDetailList}>
-                  <p className={classes.fileDetail}>size</p>
-                  <div className={classes.divider} />
-                  <p className={classes.fileDetail}>type</p>
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
+        <div className={classes.messageContainer}>
+          {data &&
+            data.length > 0 &&
+            data.map(file => <UploadedFile file={file} />)}
+          {loading && <UploadingFile />}
+        </div>
       </FormControl>
     );
 
@@ -263,7 +305,14 @@
 
     B.defineFunction('clearFileUpload', e => clearFiles(e));
 
-    return isDev ? <div className={classes.root}>{Control}</div> : Control;
+    return isDev ? (
+      <div>
+        <div className={classes.root}>{Control}</div>
+        <DevUploadedFile />
+      </div>
+    ) : (
+      Control
+    );
   })(),
   styles: B => t => {
     const style = new B.Styling(t);
@@ -360,6 +409,19 @@
         display: 'flex',
         alignItems: 'center',
       },
+      devImage: {
+        display: 'flex',
+        overflow: 'hidden',
+        margin: '0.9375rem',
+        borderStyle: 'dashed',
+        borderColor: '#AFB5C8',
+        borderRadius: '0.3rem',
+        borderWidth: '0.0625rem',
+        backgroundColor: '#F0F1F5',
+        border: '2px dashed black',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
+      },
       placeholderImage: {
         color: 'white',
         display: 'flex',
@@ -395,8 +457,8 @@
         alignItems: 'center',
       },
       divider: {
-        width: '0.19rem',
-        height: '0.19rem',
+        width: '0.1875rem',
+        height: '0.1875rem',
         borderRadius: '50%',
         marginLeft: '0.625rem',
         backgroundColor: 'red',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -195,13 +195,15 @@
     const Hr = () => <hr className={classes.hr} />;
 
     const DeleteButton = ({ file }) => (
-      <IconButton
-        size="small"
-        className={classes.remove}
-        onClick={file ? () => removeFileFromList(file.url) : {}}
-      >
-        <Delete className={classes.deleteIcon} fontSize="small" />
-      </IconButton>
+      <div className={classes.DeleteButtonWrapper}>
+        <IconButton
+          size="small"
+          className={classes.remove}
+          onClick={file ? () => removeFileFromList(file.url) : {}}
+        >
+          <Delete className={classes.deleteIcon} fontSize="small" />
+        </IconButton>
+      </div>
     );
     const FileDetails = ({ file, fileType, fileSize }) => (
       <div className={classes.fileDetails}>
@@ -608,6 +610,9 @@
         margin: 0,
         border: 'none',
         backgroundColor: t.colors.light,
+      },
+      DeleteButtonWrapper: {
+        margin: ({ options: { type } }) => (type === 'list' ? '0.9375rem' : 0),
       },
       remove: {
         height: '1.875rem',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -260,6 +260,10 @@
         item => item.name === file.name,
       );
 
+      if (!multiple) {
+        B.triggerEvent('onFileUpload', file.url);
+      }
+
       switch (type) {
         case 'grid':
           return (

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -596,7 +596,7 @@
           options: { type, imagePreviewWidth, showImagePreview },
         }) =>
           showImagePreview && type === 'grid'
-            ? `${parseInt(imagePreviewWidth, 10) - 58}px`
+            ? `calc(${imagePreviewWidth} - 60px)`
             : 'auto',
         display: 'flex',
         flexDirection: 'column',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -14,7 +14,7 @@
       IconButton,
     } = window.MaterialUI.Core;
     const { Icons } = window.MaterialUI;
-    const { Close } = Icons;
+    const { Delete, CloudUpload } = Icons;
     const {
       hideDefaultError,
       disabled,
@@ -31,6 +31,7 @@
       hideLabel,
       customModelAttribute: customModelAttributeObj,
       nameAttribute,
+      showImagePreview,
     } = options;
 
     const isDev = env === 'dev';
@@ -203,19 +204,52 @@
         {data && data.length > 0 && (
           <div className={classes.messageContainer}>
             {data.map(file => (
-              <div className={classes.fileList}>
-                <Typography variant="body1" noWrap className={classes.span}>
-                  {file.name}
-                </Typography>
-                <IconButton
-                  className={classes.remove}
-                  size="small"
-                  onClick={() => removeFileFromList(file.url)}
-                >
-                  <Close fontSize="small" />
-                </IconButton>
-              </div>
+              <>
+                <hr className={classes.hr} />
+                <div className={classes.fileList}>
+                  {showImagePreview && <div className={classes.image} />}
+                  <div className={classes.fileDetails}>
+                    <Typography variant="body1" noWrap className={classes.span}>
+                      {file.name}
+                    </Typography>
+                    <div className={classes.fileDetailList}>
+                      <p className={classes.fileDetail}>size</p>
+                      <div className={classes.divider} />
+                      <p className={classes.fileDetail}>type</p>
+                    </div>
+                  </div>
+                  <IconButton
+                    size="small"
+                    className={classes.remove}
+                    onClick={() => removeFileFromList(file.url)}
+                  >
+                    <Delete fontSize="small" />
+                  </IconButton>
+                </div>
+              </>
             ))}
+          </div>
+        )}
+        {loading && (
+          <div style={{ paddingTop: files.length === 0 ? '0' : '1.25rem' }}>
+            <hr className={classes.hr} />
+            <div className={classes.fileList}>
+              {showImagePreview && (
+                <div className={classes.placeholderImage}>
+                  <CloudUpload />
+                </div>
+              )}
+              <div className={classes.fileDetails}>
+                <Typography variant="body1" noWrap className={classes.span}>
+                  uploading
+                </Typography>
+                <div className={classes.fileDetailList}>
+                  <p className={classes.fileDetail}>size</p>
+                  <div className={classes.divider} />
+                  <p className={classes.fileDetail}>type</p>
+                </div>
+              </div>
+            </div>
           </div>
         )}
       </FormControl>
@@ -326,8 +360,57 @@
         display: 'flex',
         alignItems: 'center',
       },
+      placeholderImage: {
+        color: 'white',
+        display: 'flex',
+        overflow: 'hidden',
+        margin: '0.9375rem',
+        alignItems: 'center',
+        backgroundColor: 'red',
+        borderRadius: '0.3rem',
+        justifyContent: 'center',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
+      },
+      image: {
+        overflow: 'hidden',
+        margin: '0.9375rem',
+        borderRadius: '0.3rem',
+        backgroundSize: 'cover',
+        width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
+        height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
+        backgroundImage: 'url("")',
+      },
+      fileDetails: {
+        flexGrow: 1,
+        display: 'flex',
+        flexDirection: 'column',
+      },
+      fileDetail: {
+        margin: 0,
+        color: 'red',
+      },
+      fileDetailList: {
+        display: 'flex',
+        alignItems: 'center',
+      },
+      divider: {
+        width: '0.19rem',
+        height: '0.19rem',
+        borderRadius: '50%',
+        marginLeft: '0.625rem',
+        backgroundColor: 'red',
+        marginRight: '0.625rem',
+      },
+      hr: {
+        height: 1,
+        margin: 0,
+        border: 'none',
+        backgroundColor: 'red',
+      },
       remove: {
-        padding: ['0.25rem', '!important'],
+        margin: '0.9375rem!important',
+        padding: '0.25rem!important',
       },
     };
   },

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -52,8 +52,18 @@
       customModelAttribute || {};
     const nameAttributeValue = useText(nameAttribute);
     const requiredText = required ? '*' : '';
+    const [uploadedFileArray, setUploadedFileArray] = useState([]);
+
+    const formatBytes = bytes => {
+      if (bytes === 0) return '0 Bytes';
+      const k = 1024;
+      const sizes = ['Bytes', 'KB', 'MB'];
+      const i = Math.floor(Math.log(bytes) / Math.log(k));
+      return `${parseFloat(bytes / k ** i).toFixed()} ${sizes[i]}`;
+    };
 
     const handleChange = e => {
+      setUploadedFileArray(prev => [...prev, ...e.target.files]);
       setUploads({
         ...uploads,
         files: e.target.files,
@@ -193,15 +203,19 @@
         <Delete className={classes.deleteIcon} fontSize="small" />
       </IconButton>
     );
-    const FileDetails = ({ file }) => (
+    const FileDetails = ({ file, fileType, fileSize }) => (
       <div className={classes.fileDetails}>
         <Typography variant="body1" noWrap className={classes.span}>
           {file ? file.name : 'File name'}
         </Typography>
         <div className={classes.fileDetailList}>
-          <p className={classes.fileDetail}>{isDev ? 'Size' : 'Size'}</p>
+          <p className={classes.fileDetail}>
+            {isDev ? 'Size' : formatBytes(fileSize)}
+          </p>
           <div className={classes.divider} />
-          <p className={classes.fileDetail}>{isDev ? 'Type' : 'Type'}</p>
+          <p className={classes.fileDetail}>
+            {isDev ? 'Type' : fileType.replace('image/', '.')}
+          </p>
         </div>
       </div>
     );
@@ -213,8 +227,10 @@
             <>
               <Hr />
               <div className={classes.listView}>
-                {showImagePreview && <div className={classes.devImage} />}
-                <FileDetails />
+                <div className={classes.fileDetailList}>
+                  {showImagePreview && <div className={classes.devImage} />}
+                  <FileDetails />
+                </div>
                 <DeleteButton />
               </div>
             </>
@@ -238,21 +254,31 @@
     };
 
     const UploadedFile = ({ file }) => {
+      const uploadedFile = uploadedFileArray.find(
+        item => item.name === file.name,
+      );
+
       switch (type) {
         case 'list':
           return (
             <>
               <Hr />
               <div className={classes.listView}>
-                {showImagePreview && (
-                  <div
-                    style={{
-                      backgroundImage: `url("${file.url}")`,
-                    }}
-                    className={classes.image}
+                <div className={classes.fileDetailList}>
+                  {showImagePreview && (
+                    <div
+                      style={{
+                        backgroundImage: `url("${file.url}")`,
+                      }}
+                      className={classes.image}
+                    />
+                  )}
+                  <FileDetails
+                    file={file}
+                    fileType={uploadedFile.type}
+                    fileSize={uploadedFile.size}
                   />
-                )}
-                <FileDetails file={file} />
+                </div>
                 <DeleteButton file={file} />
               </div>
             </>
@@ -272,7 +298,11 @@
                     />
                   )}
                   <div className={classes.gridItemDetails}>
-                    <FileDetails file={file} />
+                    <FileDetails
+                      file={file}
+                      fileType={uploadedFile.type}
+                      fileSize={uploadedFile.size}
+                    />
                     <DeleteButton file={file} />
                   </div>
                 </div>
@@ -465,6 +495,7 @@
       listView: {
         display: 'flex',
         alignItems: 'center',
+        justifyContent: 'space-between',
       },
       gridView: {
         display: 'flex',

--- a/src/components/fileUpload.js
+++ b/src/components/fileUpload.js
@@ -199,9 +199,9 @@
           {file ? file.name : 'File name'}
         </Typography>
         <div className={classes.fileDetailList}>
-          <p className={classes.fileDetail}>Size</p>
+          <p className={classes.fileDetail}>{isDev ? 'Size' : 'Size'}</p>
           <div className={classes.divider} />
-          <p className={classes.fileDetail}>Type</p>
+          <p className={classes.fileDetail}>{isDev ? 'Type' : 'Type'}</p>
         </div>
       </div>
     );
@@ -212,7 +212,7 @@
           return (
             <>
               <Hr />
-              <div className={classes.fileList}>
+              <div className={classes.listView}>
                 {showImagePreview && <div className={classes.devImage} />}
                 <FileDetails />
                 <DeleteButton />
@@ -225,7 +225,7 @@
             <>
               <div className={classes.gridView}>
                 <div className={classes.gridItem}>
-                  {showImagePreview && <div className={classes.devImageGrid} />}
+                  {showImagePreview && <div className={classes.gridDevImage} />}
                   <div className={classes.gridItemDetails}>
                     <FileDetails />
                     <DeleteButton />
@@ -243,7 +243,7 @@
           return (
             <>
               <Hr />
-              <div className={classes.fileList}>
+              <div className={classes.listView}>
                 {showImagePreview && (
                   <div
                     style={{
@@ -268,7 +268,7 @@
                       style={{
                         backgroundImage: `url("${file.url}")`,
                       }}
-                      className={classes.imageGrid}
+                      className={classes.gridImage}
                     />
                   )}
                   <div className={classes.gridItemDetails}>
@@ -288,7 +288,7 @@
           return (
             <>
               <Hr />
-              <div className={classes.fileList}>
+              <div className={classes.listView}>
                 {showImagePreview && (
                   <div className={classes.uploadingImage}>
                     <CloudUpload />
@@ -307,7 +307,7 @@
               <div className={classes.gridView}>
                 <div className={classes.gridItem}>
                   {showImagePreview && (
-                    <div className={classes.uploadingImageGrid}>
+                    <div className={classes.gridUploadingImage}>
                       <CloudUpload />
                     </div>
                   )}
@@ -462,7 +462,7 @@
           ],
         },
       },
-      fileList: {
+      listView: {
         display: 'flex',
         alignItems: 'center',
       },
@@ -478,6 +478,8 @@
         marginBottom: '0.9375rem',
       },
       gridItemDetails: {
+        maxWidth: ({ options: { imagePreviewWidth, showImagePreview } }) =>
+          showImagePreview ? imagePreviewWidth : 'auto',
         display: 'flex',
         margin: '0.9375rem',
         justifyContent: 'space-between',
@@ -495,7 +497,7 @@
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
-      devImageGrid: {
+      gridDevImage: {
         extend: 'devImage',
 
         margin: 0,
@@ -519,7 +521,7 @@
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
-      uploadingImageGrid: {
+      gridUploadingImage: {
         extend: 'uploadingImage',
 
         margin: 0,
@@ -535,7 +537,7 @@
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
-      imageGrid: {
+      gridImage: {
         margin: 0,
         overflow: 'hidden',
         backgroundSize: 'cover',
@@ -545,6 +547,12 @@
       },
       fileDetails: {
         flexGrow: 1,
+        maxWidth: ({
+          options: { type, imagePreviewWidth, showImagePreview },
+        }) =>
+          showImagePreview && type === 'grid'
+            ? `calc(${imagePreviewWidth} - 58px)`
+            : 'auto',
         display: 'flex',
         flexDirection: 'column',
       },

--- a/src/components/media.js
+++ b/src/components/media.js
@@ -18,7 +18,8 @@
     const titleText = useText(title);
     const videoUrl = useText(videoSource);
     const iframeUrl = useText(iframeSource);
-    const [imgUrl, setImgUrl] = useState(useText(imageSource));
+    const imageSourceText = useText(imageSource);
+    const [imgUrl, setImgUrl] = useState(imageSourceText);
 
     const isVideo = type === 'video' && videoUrl;
     const isIframe = type === 'iframe' && iframeUrl;
@@ -26,7 +27,7 @@
     const [isEmpty, setIsEmpty] = useState(!isImage && !isVideo && !isIframe);
 
     useEffect(() => {
-      setImgUrl(useText(imageSource));
+      setImgUrl(imageSourceText);
     }, [imageSource]);
 
     useEffect(() => {

--- a/src/components/media.js
+++ b/src/components/media.js
@@ -21,28 +21,22 @@
     const imageSourceText = useText(imageSource);
     const [imgUrl, setImgUrl] = useState(imageSourceText);
 
-    const isVideo = type === 'video' && videoUrl;
-    const isIframe = type === 'iframe' && iframeUrl;
-    const [isImage, setIsImage] = useState(type === 'img' && imgUrl);
-    const [isEmpty, setIsEmpty] = useState(!isImage && !isVideo && !isIframe);
-
     useEffect(() => {
       setImgUrl(imageSourceText);
-    }, [imageSource]);
+    }, [imageSourceText]);
 
-    useEffect(() => {
-      setIsImage(type === 'img' && imgUrl);
-    }, [type, imgUrl]);
-
-    useEffect(() => {
-      setIsEmpty(!isImage && !isVideo && !isIframe);
-    }, [isImage, isVideo, isIframe]);
-
-    B.defineFunction('SetImage', url => {
-      setIsImage(true);
+    B.defineFunction('SetCustomImage', url => {
       setImgUrl(url);
-      setIsEmpty(false);
     });
+
+    B.defineFunction('RemoveCustomImage', () => {
+      setImgUrl(imageSourceText);
+    });
+
+    const isImage = type === 'img' && imgUrl;
+    const isVideo = type === 'video' && videoUrl;
+    const isIframe = type === 'iframe' && iframeUrl;
+    const isEmpty = !isImage && !isVideo && !isIframe;
 
     const variable = imageSource && imageSource.findIndex(v => v.name) !== -1;
     const variableDev = env === 'dev' && (variable || !imgUrl);

--- a/src/components/media.js
+++ b/src/components/media.js
@@ -16,14 +16,32 @@
     } = options;
 
     const titleText = useText(title);
-    const imgUrl = useText(imageSource);
     const videoUrl = useText(videoSource);
     const iframeUrl = useText(iframeSource);
+    const [imgUrl, setImgUrl] = useState(useText(imageSource));
 
-    const isImage = type === 'img' && imgUrl;
     const isVideo = type === 'video' && videoUrl;
     const isIframe = type === 'iframe' && iframeUrl;
-    const isEmpty = !isImage && !isVideo && !isIframe;
+    const [isImage, setIsImage] = useState(type === 'img' && imgUrl);
+    const [isEmpty, setIsEmpty] = useState(!isImage && !isVideo && !isIframe);
+
+    useEffect(() => {
+      setImgUrl(useText(imageSource));
+    }, [imageSource]);
+
+    useEffect(() => {
+      setIsImage(type === 'img' && imgUrl);
+    }, [type, imgUrl]);
+
+    useEffect(() => {
+      setIsEmpty(!isImage && !isVideo && !isIframe);
+    }, [isImage, isVideo, isIframe]);
+
+    B.defineFunction('SetImage', url => {
+      setIsImage(true);
+      setImgUrl(url);
+      setIsEmpty(false);
+    });
 
     const variable = imageSource && imageSource.findIndex(v => v.name) !== -1;
     const variableDev = env === 'dev' && (variable || !imgUrl);

--- a/src/prefabs/fileUpload.js
+++ b/src/prefabs/fileUpload.js
@@ -16,6 +16,26 @@
           },
         },
         {
+          type: 'CUSTOM',
+          label: 'Type',
+          key: 'type',
+          value: 'list',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              {
+                name: 'List',
+                value: 'list',
+              },
+              {
+                name: 'Grid',
+                value: 'grid',
+              },
+            ],
+          },
+        },
+        {
           type: 'TOGGLE',
           label: 'Show Image preview',
           value: false,

--- a/src/prefabs/fileUpload.js
+++ b/src/prefabs/fileUpload.js
@@ -16,6 +16,42 @@
           },
         },
         {
+          type: 'TOGGLE',
+          label: 'Show Image preview',
+          value: false,
+          key: 'showImagePreview',
+        },
+        {
+          type: 'SIZE',
+          label: 'Image preview width',
+          key: 'imagePreviewWidth',
+          value: '90px',
+          configuration: {
+            as: 'UNIT',
+            condition: {
+              type: 'SHOW',
+              option: 'showImagePreview',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          type: 'SIZE',
+          label: 'Image preview height',
+          key: 'imagePreviewHeight',
+          value: '60px',
+          configuration: {
+            as: 'UNIT',
+            condition: {
+              type: 'SHOW',
+              option: 'showImagePreview',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
           value: false,
           label: 'Hide default error',
           key: 'hideDefaultError',

--- a/src/prefabs/fileUpload.js
+++ b/src/prefabs/fileUpload.js
@@ -45,7 +45,7 @@
           type: 'SIZE',
           label: 'Image preview width',
           key: 'imagePreviewWidth',
-          value: '90px',
+          value: '200px',
           configuration: {
             as: 'UNIT',
             condition: {
@@ -60,7 +60,7 @@
           type: 'SIZE',
           label: 'Image preview height',
           key: 'imagePreviewHeight',
-          value: '60px',
+          value: '112px',
           configuration: {
             as: 'UNIT',
             condition: {

--- a/src/prefabs/imageUpload.js
+++ b/src/prefabs/imageUpload.js
@@ -7,7 +7,7 @@
       name: 'FileUpload',
       options: [
         {
-          value: { label: ['Select files(s)...'] },
+          value: { label: ['Select image(s)...'] },
           label: 'Label',
           key: 'customModelAttribute',
           type: 'CUSTOM_MODEL_ATTRIBUTE',
@@ -155,7 +155,7 @@
         {
           label: 'Button icon',
           key: 'icon',
-          value: 'None',
+          value: 'Image',
           type: 'CUSTOM',
           configuration: {
             as: 'DROPDOWN',

--- a/src/prefabs/imageUpload.js
+++ b/src/prefabs/imageUpload.js
@@ -1,6 +1,6 @@
 (() => ({
-  name: 'FileUpload',
-  icon: 'FileInputIcon',
+  name: 'imageUpload',
+  icon: 'ImageInputIcon',
   category: 'FORM',
   structure: [
     {
@@ -13,6 +13,62 @@
           type: 'CUSTOM_MODEL_ATTRIBUTE',
           configuration: {
             allowedTypes: ['file'],
+          },
+        },
+        {
+          type: 'CUSTOM',
+          label: 'Type',
+          key: 'type',
+          value: 'list',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              {
+                name: 'List',
+                value: 'list',
+              },
+              {
+                name: 'Grid',
+                value: 'grid',
+              },
+            ],
+          },
+        },
+        {
+          type: 'TOGGLE',
+          label: 'Show Image preview',
+          value: true,
+          key: 'showImagePreview',
+        },
+        {
+          type: 'SIZE',
+          label: 'Image preview width',
+          key: 'imagePreviewWidth',
+          value: '200px',
+          configuration: {
+            as: 'UNIT',
+            condition: {
+              type: 'SHOW',
+              option: 'showImagePreview',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          type: 'SIZE',
+          label: 'Image preview height',
+          key: 'imagePreviewHeight',
+          value: '112px',
+          configuration: {
+            as: 'UNIT',
+            condition: {
+              type: 'SHOW',
+              option: 'showImagePreview',
+              comparator: 'EQ',
+              value: true,
+            },
           },
         },
         {


### PR DESCRIPTION
Using JSS's `extend` doesn't seem to work when using dynamic options from the prefab.. for example:
```jsx 
class1: {
  width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
},
class2: {
  extend: 'image',
  // the width will not be given through to this class2
}
```
This is why the width and height properties are set quite a few times in the style.

[Related Jira ticket](https://bettyblocks.atlassian.net/jira/software/projects/WORK/boards/471?selectedIssue=WORK-42)

# Testing
## Using image previews in the component itself
- Drag the ImageUpload prefab to the canvas
- There should be some new options to configure (type, show image preview & image preview width/height)
<img width="247" alt="Screenshot 2021-01-14 at 09 43 08" src="https://user-images.githubusercontent.com/6746411/104565791-1897bc80-564d-11eb-9fce-369f9f52d7aa.png">
- These options should affect the dev-env preview as well as the run-time after compiling.

## Using image previews via interactions
When the 'allow multiple' checkbox is turned off, you're able to preview the image in a separate box component (as a background image) or media component using interactions.
- drag an imageUpload, box and media component to the canvas.
- uncheck 'show image preview' in the imageUpload, as we will be displaying the image in the other components.
- add 2 new interactions via the imageUpload prefab. 
- for the first interaction, use these options to display the image on a box component:
![Screenshot 2021-01-14 at 09 51 16](https://user-images.githubusercontent.com/6746411/104566578-0ff3b600-564e-11eb-977c-b8aed1399e04.png)
- for the second interaction use these options to show the image on a media component
![Screenshot 2021-01-14 at 09 52 08](https://user-images.githubusercontent.com/6746411/104566668-2ef24800-564e-11eb-85b7-ba4ace850a00.png)
- compile the page and upload an image, the image should be displayed on the box and media components.
