### PR TITLE
fix(ART-2906): Remove validation from password field.

### DIFF
--- a/src/prefabs/loginForm.js
+++ b/src/prefabs/loginForm.js
@@ -1803,7 +1803,7 @@
                         {
                           label: 'Validation pattern',
                           key: 'pattern',
-                          value: '(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}',
+                          value: '',
                           type: 'TEXT',
                           configuration: {
                             placeholder: '(?=.*\\d)(?=.*[a-z])(?=.*[A-Z]).{8,}',


### PR DESCRIPTION
When logging in, it is not required to enter a password with x
characters, a number and a capital letter. This commit removes the
validation.