### PR TITLE
fix: dialog component not being shown correctly inside the box component

### DIFF
--- a/src/components/box.js
+++ b/src/components/box.js
@@ -127,7 +127,7 @@
         height: ({ options: { height } }) => (isDev ? '100%' : height),
         minHeight: 0,
         position: ({ options: { position } }) =>
-          (!isDev && position) || 'relative',
+          (!isDev && position) || 'unset',
         top: ({ options: { top } }) => !isDev && top,
         right: ({ options: { right } }) => !isDev && right,
         bottom: ({ options: { bottom } }) => !isDev && bottom,

--- a/src/prefabs/deleteRecord.js
+++ b/src/prefabs/deleteRecord.js
@@ -221,7 +221,7 @@
           type: 'TOGGLE',
         },
         {
-          value: 'relative',
+          value: 'static',
           label: 'Position',
           key: 'position',
           type: 'CUSTOM',


### PR DESCRIPTION
  - Users can now see the dialog correctly inside the deleteRecord prefab