### PR TITLE
fix: fix optiontype setting for list property in prefab

### DIFF
--- a/src/prefabs/createForm.js
+++ b/src/prefabs/createForm.js
@@ -7865,7 +7865,7 @@
                       {
                         label: 'Option type',
                         key: 'optionType',
-                        value: 'static',
+                        value: 'property',
                         type: 'CUSTOM',
                         configuration: {
                           as: 'BUTTONGROUP',

--- a/src/prefabs/updateForm.js
+++ b/src/prefabs/updateForm.js
@@ -7935,7 +7935,7 @@
                       {
                         label: 'Option type',
                         key: 'optionType',
-                        value: 'static',
+                        value: 'property',
                         type: 'CUSTOM',
                         configuration: {
                           as: 'BUTTONGROUP',


### PR DESCRIPTION
<img width="320" alt="Screen Shot 2021-01-21 at 19 03 31" src="https://user-images.githubusercontent.com/32203526/105393595-d22df900-5c1c-11eb-825b-494ed23ec1e2.png">

When list property was selected in beforeCreate wizard property type was set incorrectly in prefab
