### PR TITLE
fix: use model_name for the variable name instead of the label

### DIFF
--- a/src/prefabs/deleteRecord.js
+++ b/src/prefabs/deleteRecord.js
@@ -52,7 +52,7 @@
               return;
             }
             const newPrefab = { ...prefab };
-            newPrefab.variables[0].name = camelToSnakeCase(model.label);
+            newPrefab.variables[0].name = camelToSnakeCase(model.name);
             newPrefab.structure[0].descendants[1].descendants[0].descendants[0].descendants[0].descendants[2].descendants[1].options[7].value = [
               modelId,
             ];


### PR DESCRIPTION
- Use the modelName instead of the modelLabel because in the runtime artifact only the modelName is available.