### PR TITLE
fix: useFilter with _or fails when using search in data table

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -147,12 +147,15 @@
         )
       : {};
 
+    const resolvedFilter = useFilter(filter);
+    const resolvedSearchFilter = useFilter(searchFilter);
+
     const newFilter =
       searchProperty && searchTerm !== ''
-        ? deepMerge(filter, searchFilter)
-        : filter;
+        ? deepMerge(resolvedFilter, resolvedSearchFilter)
+        : resolvedFilter;
 
-    const where = useFilter(newFilter);
+    const where = newFilter;
 
     const { loading, error, data, refetch } =
       model &&


### PR DESCRIPTION
When you use a filter with multiple rows and OR, and also apply a search property in the data table the useFilter helper fails resulting in an error `Property in filter not found`. This change fixes that by first resolving both the filter and search property filter via useFilter and then combining them.