### PR TITLE
feat: disable backdrop click for dialog

### DIFF
--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -5,7 +5,12 @@
   orientation: 'VERTICAL',
   jsx: (() => {
     const { env } = B;
-    const { isVisible, isFullscreen, width, disableBackdropClick } = options;
+    const {
+      isVisible,
+      isFullscreen,
+      width,
+      disableClick: disableBackdropClick,
+    } = options;
     const { Dialog } = window.MaterialUI.Core;
     const isDev = env === 'dev';
     const [isOpen, setIsOpen] = useState(isVisible);

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -5,7 +5,7 @@
   orientation: 'VERTICAL',
   jsx: (() => {
     const { env } = B;
-    const { isVisible, isFullscreen, width } = options;
+    const { isVisible, isFullscreen, width, disableBackdropClick } = options;
     const { Dialog } = window.MaterialUI.Core;
     const isDev = env === 'dev';
     const [isOpen, setIsOpen] = useState(isVisible);
@@ -44,6 +44,7 @@
         maxWidth={width}
         aria-labelledby="modal-dialog"
         keepMounted
+        disableBackdropClick
       >
         {children}
       </Dialog>

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -44,7 +44,7 @@
         maxWidth={width}
         aria-labelledby="modal-dialog"
         keepMounted
-        disableBackdropClick
+        disableBackdropClick={disableBackdropClick}
       >
         {children}
       </Dialog>

--- a/src/prefabs/dialog.js
+++ b/src/prefabs/dialog.js
@@ -48,7 +48,7 @@
         {
           type: 'TOGGLE',
           label: 'Disable backdrop click',
-          key: 'disableBackdropClick',
+          key: 'disableClick',
           value: false,
         },
         {

--- a/src/prefabs/dialog.js
+++ b/src/prefabs/dialog.js
@@ -46,6 +46,12 @@
           value: false,
         },
         {
+          type: 'TOGGLE',
+          label: 'Disable backdrop click',
+          key: 'disableBackdropClick',
+          value: false,
+        },
+        {
           value: 'sm',
           label: 'Width',
           key: 'width',


### PR DESCRIPTION
Add toggle to dialog to disable backdrop click so people can not close dialog by clicking outside of it