### PR TITLE
Feat/box backgroundattachment

### DIFF
--- a/src/components/box.js
+++ b/src/components/box.js
@@ -227,7 +227,7 @@
         backgroundRepeat: ({ options: { backgroundRepeat } }) =>
           backgroundRepeat,
         backgroundAttachment: ({ options: { backgroundAttachment } }) =>
-          backgroundAttachmentr,
+          backgroundAttachment,
       },
       border: {
         borderWidth: ({ options: { borderWidth, borderStyle, borderColor } }) =>

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -227,7 +227,7 @@
         backgroundRepeat: ({ options: { backgroundRepeat } }) =>
           backgroundRepeat,
         backgroundAttachment: ({ options: { backgroundAttachment } }) =>
-          backgroundAttachment,
+          backgroundAttachmentr,
       },
       border: {
         borderWidth: ({ options: { borderWidth, borderStyle, borderColor } }) =>

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -69,9 +69,9 @@
         style={
           interactionBackground
             ? {
-              backgroundImage: interactionBackground,
-              opacity,
-            }
+                backgroundImage: interactionBackground,
+                opacity,
+              }
             : { opacity }
         }
       >
@@ -214,9 +214,9 @@
           backgroundColor === 'Transparent'
             ? style.getColor(backgroundColor)
             : getColorAlpha(
-              style.getColor(backgroundColor),
-              backgroundColorAlpha / 100,
-            ),
+                style.getColor(backgroundColor),
+                backgroundColorAlpha / 100,
+              ),
         backgroundImage: ({ options: { backgroundUrl } }) => {
           const image = useText(backgroundUrl);
           return image && `url("${image}")`;

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -69,9 +69,9 @@
         style={
           interactionBackground
             ? {
-                backgroundImage: interactionBackground,
-                opacity,
-              }
+              backgroundImage: interactionBackground,
+              opacity,
+            }
             : { opacity }
         }
       >
@@ -214,9 +214,9 @@
           backgroundColor === 'Transparent'
             ? style.getColor(backgroundColor)
             : getColorAlpha(
-                style.getColor(backgroundColor),
-                backgroundColorAlpha / 100,
-              ),
+              style.getColor(backgroundColor),
+              backgroundColorAlpha / 100,
+            ),
         backgroundImage: ({ options: { backgroundUrl } }) => {
           const image = useText(backgroundUrl);
           return image && `url("${image}")`;
@@ -226,6 +226,8 @@
           backgroundPosition,
         backgroundRepeat: ({ options: { backgroundRepeat } }) =>
           backgroundRepeat,
+        backgroundAttachment: ({ options: { backgroundAttachment } }) =>
+          backgroundAttachment,
       },
       border: {
         borderWidth: ({ options: { borderWidth, borderStyle, borderColor } }) =>

--- a/src/prefabs/box.js
+++ b/src/prefabs/box.js
@@ -289,6 +289,27 @@
           },
         },
         {
+          value: 'inherit',
+          label: 'Background attachment',
+          key: 'backgroundAttachment',
+          type: 'CUSTOM',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              { name: 'Inherit', value: 'inherit' },
+              { name: 'Scroll', value: 'scroll' },
+              { name: 'Fixed', value: 'fixed' },
+            ],
+            condition: {
+              type: 'SHOW',
+              option: 'backgroundOptions',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
           value: 'Transparent',
           label: 'Border color',
           key: 'borderColor',


### PR DESCRIPTION
With this option you have the ability to define if you want to have a static background image or not. In this you you can prevent the background image from 'jumping' when pages have different heights or tabs within the page have different heights.