### PR TITLE
fix: replace model param with query art 2986

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.100.0](https://github.com/bettyblocks/material-ui-component-set/compare/v1.99.0...v1.100.0) (2021-02-15)
+
+
+### Features
+
+* add login interaction ([989f01b](https://github.com/bettyblocks/material-ui-component-set/commit/989f01b3eebabc76c36c0e7842713b9bdffbf4a8))
+
 # [1.99.0](https://github.com/bettyblocks/material-ui-component-set/compare/v1.98.2...v1.99.0) (2021-02-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "1.99.0",
+  "version": "1.100.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/prefabs/createForm.js
+++ b/src/prefabs/createForm.js
@@ -15,15 +15,20 @@
       PropertiesSelector,
       Text,
     },
+    helpers: { useModelQuery },
   }) => {
     const [modelId, setModelId] = React.useState('');
-    const [model, setModel] = React.useState(null);
     const [properties, setProperties] = React.useState([]);
     const [showValidation, setShowValidation] = React.useState(false);
 
+    const { data } = useModelQuery({
+      variables: { id: modelId },
+      skip: !modelId,
+    });
+
     React.useEffect(() => {
       setProperties([]);
-    }, [model]);
+    }, [data]);
 
     return (
       <>
@@ -31,9 +36,8 @@
         <Content>
           <Field label="Select model">
             <ModelSelector
-              onChange={(id, modelObject) => {
+              onChange={id => {
                 setShowValidation(false);
-                setModel(modelObject);
                 setModelId(id);
               }}
               value={modelId}
@@ -89,8 +93,8 @@
               return;
             }
             const newPrefab = { ...prefab };
-            if (model) {
-              newPrefab.variables[1].name = camelToSnakeCase(model.label);
+            if (data && data.model) {
+              newPrefab.variables[1].name = camelToSnakeCase(data.model.label);
             }
             newPrefab.structure[0].options[0].value.modelId = modelId;
             newPrefab.structure[0].options[1].value = modelId;

--- a/src/prefabs/deleteRecord.js
+++ b/src/prefabs/deleteRecord.js
@@ -7,10 +7,15 @@
     save,
     close,
     components: { ModelSelector, Header, Content, Field, Footer, Text },
+    helpers: { useModelQuery },
   }) => {
     const [modelId, setModelId] = React.useState('');
-    const [model, setModel] = React.useState(null);
     const [showValidation, setShowValidation] = React.useState(false);
+
+    const { data } = useModelQuery({
+      variables: { id: modelId },
+      skip: !modelId,
+    });
 
     React.useEffect(() => {
       setShowValidation(false);
@@ -28,8 +33,7 @@
             info="Small note: If you can't select any models try to place the button inside a component where an object is available."
           >
             <ModelSelector
-              onChange={(id, modelObject) => {
-                setModel(modelObject);
+              onChange={id => {
                 setModelId(id);
               }}
               value={modelId}
@@ -52,7 +56,9 @@
               return;
             }
             const newPrefab = { ...prefab };
-            newPrefab.variables[0].name = camelToSnakeCase(model.name);
+            if (data && data.model) {
+              newPrefab.variables[0].name = camelToSnakeCase(data.model.name);
+            }
             newPrefab.structure[0].descendants[1].descendants[0].descendants[0].descendants[0].descendants[2].descendants[1].options[7].value = [
               modelId,
             ];

--- a/src/prefabs/updateForm.js
+++ b/src/prefabs/updateForm.js
@@ -15,11 +15,16 @@
       PropertiesSelector,
       Text,
     },
+    helpers: { useModelQuery },
   }) => {
     const [modelId, setModelId] = React.useState('');
-    const [model, setModel] = React.useState(null);
     const [properties, setProperties] = React.useState([]);
     const [showValidation, setShowValidation] = React.useState(false);
+
+    const { data } = useModelQuery({
+      variables: { id: modelId },
+      skip: !modelId,
+    });
 
     React.useEffect(() => {
       setProperties([]);
@@ -36,10 +41,9 @@
             }
           >
             <ModelSelector
-              onChange={(id, modelObject) => {
+              onChange={id => {
                 setShowValidation(false);
                 setModelId(id);
-                setModel(modelObject);
               }}
               value={modelId}
             />
@@ -100,8 +104,8 @@
             }
 
             const newPrefab = { ...prefab };
-            if (model) {
-              newPrefab.variables[1].name = camelToSnakeCase(model.label);
+            if (data && data.model) {
+              newPrefab.variables[1].name = camelToSnakeCase(data.model.label);
             }
             newPrefab.structure[0].options[0].value.modelId = modelId;
             newPrefab.structure[0].options[1].value = modelId;


### PR DESCRIPTION
  - You can now use the model query helper instead of the second param in the onChange in the model selector