### PR TITLE
Added redirect option to button on Action completed

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -23,6 +23,7 @@
       actionId,
       buttonText,
       actionModels,
+      redirect,
     } = options;
     const {
       env,
@@ -32,6 +33,7 @@
       useText,
       useAction,
       useProperty,
+      useEndpoint,
     } = B;
     const isDev = env === 'dev';
     const isAction = linkType === 'action';
@@ -41,9 +43,13 @@
       (linkToExternal && useText(linkToExternal)) || '';
     const isIcon = variant === 'icon';
     const buttonContent = useText(buttonText);
+    const history = isDev ? {} : useHistory();
 
     const [isVisible, setIsVisible] = useState(visible);
     const [isLoading, setIsLoading] = useState(false);
+
+    const hasRedirect = redirect && redirect.id !== '';
+    const redirectTo = env === 'prod' && hasRedirect && useEndpoint(redirect);
 
     const camelToSnakeCase = str =>
       str[0].toLowerCase() +
@@ -73,6 +79,9 @@
           input,
         },
         onCompleted(data) {
+          if (!isDev && hasRedirect) {
+            history.push(redirectTo);
+          }
           B.triggerEvent('onActionSuccess', data.actionb5);
         },
         onError(error) {

--- a/src/prefabs/button.js
+++ b/src/prefabs/button.js
@@ -140,6 +140,20 @@
           },
         },
         {
+          value: '',
+          label: 'Redirect after succesful submit',
+          key: 'redirect',
+          type: 'ENDPOINT',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'linkType',
+              comparator: 'EQ',
+              value: 'action',
+            },
+          },
+        },
+        {
           value: false,
           label: 'Full width',
           key: 'fullWidth',


### PR DESCRIPTION
This adds a redirect option on Action completed to the button component.

Reason is that sometimes you just want to update a status (or something like that) and afterwards redirect to another page, without the need to pass all kinds of input variables like in af from component. I've got this feedback the last 2 months multiple times from self building customers.