### PR TITLE
Feat/add styling to expanspanel title

### DIFF
--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -105,12 +105,17 @@
           getSpacing(titleSpacing[2]),
         marginLeft: ({ options: { titleSpacing } }) =>
           getSpacing(titleSpacing[3]),
-        color: ({ options: { titleTextColor } }) => style.getColor(titleTextColor),
-        fontFamily: ({ options: { titleType } }) => style.getFontFamily(titleType),
-        fontSize: ({ options: { titleType } }) => style.getFontSize(titleType),
+        color: ({ options: { titleTextColor } }) =>
+          style.getColor(titleTextColor),
+        fontFamily: ({ options: { titleType } }) =>
+          style.getFontFamily(titleType),
+        fontSize: ({ options: { titleType } }) =>
+          style.getFontSize(titleType),
         fontWeight: ({ options: { titleFontWeight } }) => titleFontWeight,
-        textTransform: ({ options: { titleType } }) => style.getTextTransform(titleType),
-        letterSpacing: ({ options: { titleType } }) => style.getLetterSpacing(titleType),
+        textTransform: ({ options: { titleType } }) =>
+          style.getTextTransform(titleType),
+        letterSpacing: ({ options: { titleType } }) =>
+          style.getLetterSpacing(titleType),
       },
 
       panelDetails: {

--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -8,6 +8,7 @@
       ExpansionPanel,
       ExpansionPanelSummary,
       ExpansionPanelDetails,
+      Typography,
     } = window.MaterialUI.Core;
     const { ExpandMore } = window.MaterialUI.Icons;
     const { useText, env } = B;
@@ -22,7 +23,7 @@
       variant,
       elevation,
     } = options;
-    const Tag = {
+    const Variant = {
       Title1: 'h1',
       Title2: 'h2',
       Title3: 'h3',
@@ -80,7 +81,7 @@
     const ExpansionPanelComponent = (
       <ExpansionPanel {...panelOptions}>
         <ExpansionPanelSummary {...panelSummaryOptions}>
-          <Tag className={classes.panelTitle}>{useText(title)}</Tag>
+          <Typography variant={Variant} className={classes.panelTitle}>{useText(title)}</Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails className={classes.panelDetails}>
           {isEmpty ? PlaceHolder : children}

--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -109,8 +109,7 @@
           style.getColor(titleTextColor),
         fontFamily: ({ options: { titleType } }) =>
           style.getFontFamily(titleType),
-        fontSize: ({ options: { titleType } }) =>
-          style.getFontSize(titleType),
+        fontSize: ({ options: { titleType } }) => style.getFontSize(titleType),
         fontWeight: ({ options: { titleFontWeight } }) => titleFontWeight,
         textTransform: ({ options: { titleType } }) =>
           style.getTextTransform(titleType),

--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -81,7 +81,9 @@
     const ExpansionPanelComponent = (
       <ExpansionPanel {...panelOptions}>
         <ExpansionPanelSummary {...panelSummaryOptions}>
-          <Typography variant={Variant} className={classes.panelTitle}>{useText(title)}</Typography>
+          <Typography variant={Variant} className={classes.panelTitle}>
+            {useText(title)}
+          </Typography>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails className={classes.panelDetails}>
           {isEmpty ? PlaceHolder : children}

--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -8,7 +8,6 @@
       ExpansionPanel,
       ExpansionPanelSummary,
       ExpansionPanelDetails,
-      Typography,
     } = window.MaterialUI.Core;
     const { ExpandMore } = window.MaterialUI.Icons;
     const { useText, env } = B;
@@ -23,6 +22,16 @@
       variant,
       elevation,
     } = options;
+    const Tag = {
+      Title1: 'h1',
+      Title2: 'h2',
+      Title3: 'h3',
+      Title4: 'h4',
+      Title5: 'h5',
+      Title6: 'h6',
+      Body1: 'p',
+      Body2: 'p',
+    }[options.titleType || 'Body1'];
 
     const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -71,7 +80,7 @@
     const ExpansionPanelComponent = (
       <ExpansionPanel {...panelOptions}>
         <ExpansionPanelSummary {...panelSummaryOptions}>
-          <Typography>{useText(title)}</Typography>
+          <Tag className={classes.panelTitle}>{useText(title)}</Tag>
         </ExpansionPanelSummary>
         <ExpansionPanelDetails className={classes.panelDetails}>
           {isEmpty ? PlaceHolder : children}
@@ -87,6 +96,23 @@
     const getSpacing = (idx, device = 'Mobile') =>
       idx === '0' ? '0rem' : style.getSpacing(idx, device);
     return {
+      panelTitle: {
+        marginTop: ({ options: { titleSpacing } }) =>
+          getSpacing(titleSpacing[0]),
+        marginRight: ({ options: { titleSpacing } }) =>
+          getSpacing(titleSpacing[1]),
+        marginBottom: ({ options: { titleSpacing } }) =>
+          getSpacing(titleSpacing[2]),
+        marginLeft: ({ options: { titleSpacing } }) =>
+          getSpacing(titleSpacing[3]),
+        color: ({ options: { titleTextColor } }) => style.getColor(titleTextColor),
+        fontFamily: ({ options: { titleType } }) => style.getFontFamily(titleType),
+        fontSize: ({ options: { titleType } }) => style.getFontSize(titleType),
+        fontWeight: ({ options: { titleFontWeight } }) => titleFontWeight,
+        textTransform: ({ options: { titleType } }) => style.getTextTransform(titleType),
+        letterSpacing: ({ options: { titleType } }) => style.getLetterSpacing(titleType),
+      },
+
       panelDetails: {
         '&.MuiExpansionPanelDetails-root': {
           paddingTop: ({ options: { innerSpacing } }) =>

--- a/src/prefabs/expansionPanel.js
+++ b/src/prefabs/expansionPanel.js
@@ -116,20 +116,6 @@
           },
         },
         {
-          type: 'COLOR',
-          label: 'Title background color',
-          key: 'titleBgColor',
-          value: 'Transparent',
-          configuration: {
-            condition: {
-              type: 'SHOW',
-              option: 'titleStyles',
-              comparator: 'EQ',
-              value: true,
-            },
-          },
-        },
-        {
           type: 'CUSTOM',
           label: 'Title font weight',
           key: 'titleFontWeight',

--- a/src/prefabs/expansionPanel.js
+++ b/src/prefabs/expansionPanel.js
@@ -82,6 +82,95 @@
           },
         },
         {
+          value: false,
+          label: 'Title styles',
+          key: 'titleStyles',
+          type: 'TOGGLE',
+        },
+        {
+          value: 'Body1',
+          label: 'Title type',
+          key: 'titleType',
+          type: 'FONT',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'titleStyles',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          type: 'COLOR',
+          label: 'Title text color',
+          key: 'titleTextColor',
+          value: 'Black',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'titleStyles',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          type: 'COLOR',
+          label: 'Title background color',
+          key: 'titleBgColor',
+          value: 'Transparent',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'titleStyles',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          type: 'CUSTOM',
+          label: 'Title font weight',
+          key: 'titleFontWeight',
+          value: '400',
+          configuration: {
+            as: 'DROPDOWN',
+            dataType: 'string',
+            allowedInput: [
+              { name: '100', value: '100' },
+              { name: '200', value: '200' },
+              { name: '300', value: '300' },
+              { name: '400', value: '400' },
+              { name: '500', value: '500' },
+              { name: '600', value: '600' },
+              { name: '700', value: '700' },
+              { name: '800', value: '800' },
+              { name: '900', value: '900' },
+            ],
+            condition: {
+              type: 'SHOW',
+              option: 'titleStyles',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
+          value: ['0rem', '0rem', '0rem', '0rem'],
+          label: 'Title outer space',
+          key: 'titleSpacing',
+          type: 'SIZES',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'titleStyles',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
+        },
+        {
           value: ['0rem', '0rem', '0rem', '0rem'],
           label: 'Outer space',
           key: 'outerSpacing',


### PR DESCRIPTION
Added styling to the expansion panel title by using the Theme builder typography. So removed Typography from Material-ui and added the Tag, copied from the standard text component