### PR TITLE
fix: only render children when datacontainer has data

### DIFF
--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -153,9 +153,12 @@
             B.triggerEvent('onNoUserResults');
           }
 
+          if (!data) {
+            return <div />;
+          }
           return (
             <MeProvider value={data} id={model}>
-              <CanvasLayout />
+              {children}
             </MeProvider>
           );
         };


### PR DESCRIPTION
Prevents the children of a datacontainer to be rendered when the data container itself is still loading its data from an authentication profile. This caused input components that use a state for the default value (like the auto complete and hidden input) to incorrectly initialize the state with an empty value.