### PR TITLE
fix row click endpoint leads to compile error

### DIFF
--- a/src/components/dataTableColumn.js
+++ b/src/components/dataTableColumn.js
@@ -26,7 +26,7 @@
     const isBooleanProperty = kind === 'boolean' || kind === 'BOOLEAN';
 
     let myEndpoint = null;
-    if (linkTo) {
+    if (linkTo && linkTo.id !== '') {
       myEndpoint = useEndpoint(linkTo);
     }
 


### PR DESCRIPTION
This fix makes sure that you do not get a "Endpoint does not exist in artifact" error when you disable the Row click endpoint on the dataTable

https://bettyblocks.atlassian.net/browse/TECHSUP-3146