### PR TITLE
feat: enable auto close on select - TMPLT-168

### DIFF
--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -19,6 +19,7 @@
       margin,
       helperText,
       disableToolbar,
+      autoOk,
       hideLabel,
       customModelAttribute: customModelAttributeObj,
       use24HourClockDateTime,
@@ -156,6 +157,7 @@
         margin={margin}
         helperText={helper}
         disableToolbar={disableToolbar}
+        autoOk={autoOk}
         format={format}
         PopoverProps={{
           classes: {

--- a/src/prefabs/createForm.js
+++ b/src/prefabs/createForm.js
@@ -5147,6 +5147,12 @@
                         value: false,
                       },
                       {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
+                      },
+                      {
                         value: 'MM/dd/yyyy',
                         label: 'Format',
                         key: 'dateFormat',
@@ -5469,6 +5475,12 @@
                         label: 'Disable Toolbar',
                         key: 'disableToolbar',
                         value: false,
+                      },
+                      {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
                       },
                       {
                         value: 'MM/dd/yyyy HH:mm:ss',
@@ -5830,6 +5842,12 @@
                         label: 'Disable Toolbar',
                         key: 'disableToolbar',
                         value: false,
+                      },
+                      {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
                       },
                       {
                         value: 'HH:mm:ss',

--- a/src/prefabs/datePicker.js
+++ b/src/prefabs/datePicker.js
@@ -37,6 +37,12 @@
           value: false,
         },
         {
+          value: true,
+          label: 'Auto close on select',
+          key: 'autoOk',
+          type: 'TOGGLE',
+        },
+        {
           label: 'Language',
           key: 'locale',
           value: 'en',

--- a/src/prefabs/dateTimePicker.js
+++ b/src/prefabs/dateTimePicker.js
@@ -37,6 +37,12 @@
           value: false,
         },
         {
+          value: true,
+          label: 'Auto close on select',
+          key: 'autoOk',
+          type: 'TOGGLE',
+        },
+        {
           label: 'Language',
           key: 'locale',
           value: 'en',

--- a/src/prefabs/timePicker.js
+++ b/src/prefabs/timePicker.js
@@ -37,6 +37,12 @@
           value: false,
         },
         {
+          value: true,
+          label: 'Auto close on select',
+          key: 'autoOk',
+          type: 'TOGGLE',
+        },
+        {
           value: 'HH:mm:ss',
           label: 'Format',
           key: 'timeFormat',

--- a/src/prefabs/updateForm.js
+++ b/src/prefabs/updateForm.js
@@ -5188,6 +5188,12 @@
                         value: false,
                       },
                       {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
+                      },
+                      {
                         value: 'MM/dd/yyyy',
                         label: 'Format',
                         key: 'dateFormat',
@@ -5516,6 +5522,12 @@
                         label: 'Disable Toolbar',
                         key: 'disableToolbar',
                         value: false,
+                      },
+                      {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
                       },
                       {
                         value: 'MM/dd/yyyy HH:mm:ss',
@@ -5883,6 +5895,12 @@
                         label: 'Disable Toolbar',
                         key: 'disableToolbar',
                         value: false,
+                      },
+                      {
+                        value: true,
+                        label: 'Auto close on select',
+                        key: 'autoOk',
+                        type: 'TOGGLE',
                       },
                       {
                         value: 'HH:mm:ss',


### PR DESCRIPTION
Enable the option to auto-close the picker modal after a value is selected. Implemented for the datePicker, dateTimePicker and timePicker. Default value is true.