### PR TITLE
fix(PAGE-211)/Datacontainer doesn't re-render after refetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.141.0](https://github.com/bettyblocks/material-ui-component-set/compare/v1.140.2...v1.141.0) (2021-06-04)
+
+
+### Features
+
+* **ta-2546:** adds option to hide the badge if value is 0 ([0c7b00a](https://github.com/bettyblocks/material-ui-component-set/commit/0c7b00a180f3d2acc0e425f5904a86d837bc2211))
+
 ## [1.140.2](https://github.com/bettyblocks/material-ui-component-set/compare/v1.140.1...v1.140.2) (2021-06-03)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "1.140.2",
+  "version": "1.141.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -74,6 +74,34 @@
         const hasFilter =
           selectedFilter && Object.keys(selectedFilter).length > 0;
 
+        const {
+          loading: oneDataLoading,
+          data: oneData,
+          error: oneError,
+          refetch,
+        } =
+          (hasFilter &&
+            useOneQuery(model, {
+              filter: getFilter(),
+              onCompleted(resp) {
+                if (resp && resp.id) {
+                  B.triggerEvent('onSuccess', resp);
+                } else {
+                  B.triggerEvent('onNoResults');
+                }
+              },
+              onError(resp) {
+                if (!displayError) {
+                  B.triggerEvent('onError', resp);
+                }
+              },
+            })) ||
+          {};
+
+        B.defineFunction('Refetch', () => {
+          refetch();
+        });
+
         if (isDev) {
           return <BuilderLayout />;
         }
@@ -83,7 +111,7 @@
             return <BuilderLayout />;
           }
 
-          return <One modelId={model} />;
+          return <One />;
         };
 
         const redirect = () => {
@@ -91,46 +119,23 @@
           history.push(useEndpoint(redirectWithoutResult));
         };
 
-        const One = ({ modelId }) => {
-          const { loading, data, error, refetch } =
-            (hasFilter &&
-              useOneQuery(modelId, {
-                filter: getFilter(),
-                onCompleted(resp) {
-                  if (resp && resp.id) {
-                    B.triggerEvent('onSuccess', resp);
-                  } else {
-                    B.triggerEvent('onNoResults');
-                  }
-                },
-                onError(resp) {
-                  if (!displayError) {
-                    B.triggerEvent('onError', resp);
-                  }
-                },
-              })) ||
-            {};
-
-          B.defineFunction('Refetch', () => {
-            refetch();
-          });
-
-          if (loading) {
-            B.triggerEvent('onLoad', loading);
+        const One = () => {
+          if (oneDataLoading) {
+            B.triggerEvent('onLoad', oneDataLoading);
             return <span>Loading...</span>;
           }
 
-          if (error && displayError) {
-            return <span>{error.message}</span>;
+          if (oneError && displayError) {
+            return <span>{oneError.message}</span>;
           }
 
-          if (!data && redirectWithoutResult) {
+          if (!oneData && redirectWithoutResult) {
             redirect();
           }
 
           return (
-            data && (
-              <ModelProvider value={data} id={model}>
+            oneData && (
+              <ModelProvider value={oneData} id={model}>
                 {children}
               </ModelProvider>
             )


### PR DESCRIPTION
Currently the datacontainer refetch function doesn't trigger a re-render even though the hooks from the useOneQuery are updated correctly. This is because the hooks are inside a constant so with this PR. I moved the useOneQuery hook outside of the constant and now it will re-render correctly