### PR TITLE
Fix/datepicker us format

### DIFF
--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -83,7 +83,7 @@
         datevalue = convertToDate(date);
       }
       B.triggerEvent('onChange', datevalue);
-      setSelectedDate(datevalue);
+      setSelectedDate(date);
     };
 
     const setDefaultDate = (defaultFormat, givenFormat) => {
@@ -116,7 +116,6 @@
         format = dateFormat || 'dd/MM/yyyy';
 
         setDefaultDate('yyyy-MM-dd', format);
-
         resultString = isValidDate(selectedDate)
           ? DateFns.format(selectedDate, 'yyyy-MM-dd')
           : null;


### PR DESCRIPTION
When using the date picker with a US date format (MM/dd/yyyy) and selecting a date with a day above 12, the date was not send to the action in the correct format resulting the date picker to be broken. This PR fixes that.