### PR TITLE
Feat/form submit without validation

### DIFF
--- a/src/components/form.js
+++ b/src/components/form.js
@@ -49,6 +49,20 @@
 
         const mounted = useRef(false);
 
+        B.defineFunction('SubmitWithoutValidation', () => {
+          if (formRef.current) {
+            formRef.current.noValidate = true;
+            if (typeof formRef.current.requestSubmit === 'function') {
+              formRef.current.requestSubmit();
+            } else {
+              formRef.current.dispatchEvent(
+                new Event('submit', { cancelable: true }),
+              );
+            }
+            formRef.current.noValidate = false;
+          }
+        });
+
         B.defineFunction('Submit', () => {
           if (formRef.current) {
             if (typeof formRef.current.requestSubmit === 'function') {


### PR DESCRIPTION
Customer request an interaction to be able to save a record as Draft and thus skip the validation. Thought it might be useful as a standard in the form component