### PR TITLE
fix: autocomplete filter assignment and css props

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -132,7 +132,7 @@
       return value;
     };
 
-    const { filter } = options;
+    const filter = { ...options.filter };
     const hasSearch = searchProp && searchProp.id;
     const hasValue = valueProp && valueProp.id;
 
@@ -442,11 +442,6 @@
           disabled={disabled}
           options={selectValues}
           value={currentValue}
-          PopoverProps={{
-            classes: {
-              root: classes.popover,
-            },
-          }}
           onInputChange={(_, inputValue) => {
             setSearchParam(inputValue);
           }}
@@ -521,11 +516,6 @@
                 inputValue={currentInputValue}
                 getOptionLabel={renderLabel}
                 getOptionSelected={(option, value) => value.id === option.id}
-                PopoverProps={{
-                  classes: {
-                    root: classes.popover,
-                  },
-                }}
                 onInputChange={(event, inputValue) => {
                   if (event) setSearchParam(inputValue);
                 }}
@@ -548,7 +538,6 @@
                       required={
                         required && (!currentValue || currentValue.length === 0)
                       }
-                      loading={loading}
                       InputProps={{
                         ...params.InputProps,
                         endAdornment: (

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -115,22 +115,22 @@
 
     const getExternalHref = config => {
       if (config.disabled) {
-        return false;
+        return undefined;
       }
       if (config.linkToExternal && config.linkToExternal.id !== '') {
         return config.linkToExternalVariable;
       }
-      return false;
+      return undefined;
     };
 
     const getInternalHref = config => {
       if (config.disabled) {
-        return false;
+        return undefined;
       }
       if (config.linkTo && config.linkTo.id !== '') {
         return config.linkToInternalVariable;
       }
-      return false;
+      return undefined;
     };
 
     const showIndicator = isLoading || loading;


### PR DESCRIPTION
Fixes the href error in the button:
![image](https://user-images.githubusercontent.com/11158471/133395601-456585b2-9983-4f07-816c-36f6b5be96fc.png)

Fixes the loading prop (which is not supported) in autocomplete:
![image](https://user-images.githubusercontent.com/11158471/133395746-055aa375-cb05-4ec0-930d-66cdcd451e98.png)

Fixes the presence of the non existing prop PopoverProps in autocomplete:
![image](https://user-images.githubusercontent.com/11158471/133395919-ea0c8a0f-e5e7-482a-b6d5-e0aff2b76124.png)

Fixes the attempt to mutate a non mutable object in the autocomplete (the filter):
![image](https://user-images.githubusercontent.com/11158471/133396030-86b1fc2e-a718-4274-9c14-46b7cc68398f.png)
