### PR TITLE
Fix/tabindex css prop value

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -155,7 +155,7 @@
 
     let inputProps = {
       inputProps: {
-        tabIndex: isDev && -1,
+        tabIndex: isDev ? -1 : undefined,
       },
       endAdornment: (
         <>

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -144,7 +144,7 @@
 
     const buttonProps = {
       disabled: disabled || isLoading || loading,
-      tabIndex: isDev && -1,
+      tabIndex: isDev ? -1 : undefined,
       onClick: event => {
         event.stopPropagation();
         actionCallback();
@@ -163,7 +163,7 @@
         linkToExternalVariable,
       }),
       target: openLinkToExternal,
-      tabIndex: isDev && -1,
+      tabIndex: isDev ? -1 : undefined,
       type: isDev ? 'button' : type,
       endpoint:
         linkType === 'internal' && linkTo && linkTo.id ? linkTo : undefined,

--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -105,7 +105,7 @@
       name: nameAttributeValue || customModelAttributeName,
       disabled,
       size,
-      tabIndex: isDev && -1,
+      tabIndex: isDev ? -1 : undefined,
       value: 'on',
       'data-component': useText(dataComponentAttribute) || 'Checkbox',
     };

--- a/src/components/checkboxGroup.js
+++ b/src/components/checkboxGroup.js
@@ -165,7 +165,7 @@
         control={
           <MUICheckbox
             required={required && !isValid}
-            tabIndex={isDev && -1}
+            tabIndex={isDev ? -1 : undefined}
             size={size}
           />
         }

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -438,8 +438,9 @@
         ));
       }
 
-      const rows = results.map(value => (
-        <ModelProvider value={value} id={model}>
+      const rows = results.map((value, index) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <ModelProvider key={`provider_${index}`} value={value} id={model}>
           <InteractionScope model={model}>
             {context => (
               <TableRow

--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -167,11 +167,11 @@
         InputProps={{
           inputProps: {
             name: nameAttributeValue || customModelAttributeName,
-            tabIndex: isDev && -1,
+            tabIndex: isDev ? -1 : undefined,
           },
         }}
         KeyboardButtonProps={{
-          tabIndex: isDev && -1,
+          tabIndex: isDev ? -1 : undefined,
         }}
         required={required}
         disabled={disabled}

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -125,7 +125,7 @@
     const generalProps = {
       disabled,
       size,
-      tabIndex: isDev && -1,
+      tabIndex: isDev ? -1 : undefined,
     };
 
     const iconButtonProps = {

--- a/src/components/radio.js
+++ b/src/components/radio.js
@@ -148,7 +148,7 @@
       <MUIFormControlLabel
         disabled={disabled}
         value={optionValue}
-        control={<Radio tabIndex={isDev && -1} size={size} />}
+        control={<Radio tabIndex={isDev ? -1 : undefined} size={size} />}
         label={optionLabel}
         labelPlacement={position}
       />

--- a/src/components/select.js
+++ b/src/components/select.js
@@ -285,7 +285,7 @@
           onBlur={validationHandler}
           inputProps={{
             name: nameAttributeValue || customModelAttributeName,
-            tabIndex: isDev ? -1 : 0,
+            tabIndex: isDev ? -1 : undefined,
             'data-component': useText(dataComponentAttribute) || 'Select',
           }}
           required={required}
@@ -304,7 +304,7 @@
           type="text"
           tabIndex="-1"
           required={required}
-          value={value}
+          defaultValue={value}
         />
       </>
     );

--- a/src/components/textField.js
+++ b/src/components/textField.js
@@ -227,7 +227,7 @@
 
     const iconButtonOptions = {
       edge: adornmentPosition,
-      tabIndex: isDev && -1,
+      tabIndex: isDev ? -1 : undefined,
     };
     if (isPasswordType) {
       iconButtonOptions.ariaLabel = 'toggle password visibility';
@@ -299,7 +299,7 @@
             maxLength: validMaxlength,
             min: validMinvalue,
             max: validMaxvalue,
-            tabIndex: isDev && -1,
+            tabIndex: isDev ? -1 : undefined,
           }}
           data-component={useText(dataComponentAttribute) || 'TextField'}
         />


### PR DESCRIPTION
Fixes tabindex issues in multiple components like this:
![image](https://user-images.githubusercontent.com/11158471/133455823-ba9779e1-b702-49b2-bf87-599fdd925b52.png)

Fixes the value in the select component (uncontrolled input):
![image](https://user-images.githubusercontent.com/11158471/133455942-4a3748b4-49e1-498b-bbaa-4c137e08b987.png)

Fixes mapped array of mediaprovider wrapping tablerows in datatable:
![image](https://user-images.githubusercontent.com/11158471/133456300-d1638da5-e1cf-485a-a874-98cbcfe00b44.png)

