### PR TITLE
Revert "fix: autoselect doesn't crash when clearing the textfield"

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -165,15 +165,13 @@
      * @returns {Void}
      */
     B.defineFunction('Filter', ({ event, property, interactionId }) => {
-      if (event) {
-        setInteractionFilter({
-          ...interactionFilter,
-          [interactionId]: {
-            property,
-            value: event.target ? event.target.value : transformValue(event),
-          },
-        });
-      }
+      setInteractionFilter({
+        ...interactionFilter,
+        [interactionId]: {
+          property,
+          value: event.target ? event.target.value : transformValue(event),
+        },
+      });
     });
 
     B.defineFunction('ResetFilter', () => {

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -165,6 +165,7 @@
      * @returns {Void}
      */
     B.defineFunction('Filter', ({ event, property, interactionId }) => {
+      if (typeof event === 'undefined') return;
       setInteractionFilter({
         ...interactionFilter,
         [interactionId]: {


### PR DESCRIPTION
This reverts commit 96f8c1841afa8694c0573eb5da88cd13eb483af5.

Filter should work with blank values