### PR TITLE
added loadOnActive option

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -16,7 +16,7 @@
       showAllTabs,
       hideTabs,
       dataComponentAttribute,
-      loadOnActive,
+      preLoadTabs,
     } = options;
 
     const orientation =
@@ -29,7 +29,7 @@
     const handleChange = (_, newValue) => {
       setValue(newValue);
       if (!activeTabs.includes(newValue)) {
-        setActiveTabs([...activeTabs, newValue]);
+        setActiveTabs(prevActiveTabs => [...prevActiveTabs, newValue]);
       }
     };
     const setSelectedTab = index => {
@@ -110,7 +110,7 @@
           children,
           (child, index) => {
             const { options: childOptions = {} } = child.props || {};
-            if (loadOnActive) {
+            if (!preLoadTabs) {
               if (isDev || showAllTabs || activeTabs.indexOf(index) !== -1) {
                 return (
                   <Children

--- a/src/prefabs/tabs.js
+++ b/src/prefabs/tabs.js
@@ -20,12 +20,6 @@
           type: 'TOGGLE',
         },
         {
-          label: 'Load tabs on activation',
-          key: 'loadOnActive',
-          value: false,
-          type: 'TOGGLE',
-        },
-        {
           type: 'SIZE',
           label: 'Height',
           key: 'height',
@@ -139,6 +133,20 @@
           label: 'Advanced settings',
           key: 'advancedSettings',
           type: 'TOGGLE',
+        },
+        {
+          label: 'Preload data in all tabs',
+          key: 'preLoadTabs',
+          value: true,
+          type: 'TOGGLE',
+          configuration: {
+            condition: {
+              type: 'SHOW',
+              option: 'advancedSettings',
+              comparator: 'EQ',
+              value: true,
+            },
+          },
         },
         {
           type: 'VARIABLE',


### PR DESCRIPTION
At this point we see at Consultancy some clients who create a lot of DataAPI requests with the usage of tabs. Initially the tabs where rendered when these where shown, however when this way of handling was removed pages could become slower because of the amount of DataAPI requests at the same time. The "Load tabs on activation" option let the tabs component work in the old way to prevent the 'misusage' of the DataAPI