### PR TITLE
Feat: add enable and disable interactions to checkbox PFR-401

### DIFF
--- a/src/components/checkbox.js
+++ b/src/components/checkbox.js
@@ -17,7 +17,7 @@
     } = options;
     const { env, useText, getCustomModelAttribute } = B;
     const isDev = env === 'dev';
-
+    const [isDisabled, setIsDisabled] = useState(disabled);
     const [errorState, setErrorState] = useState(false);
     const [helper, setHelper] = useState(useText(helperText));
     const mounted = useRef(false);
@@ -76,6 +76,8 @@
       handleValidation(isValid);
     };
 
+    B.defineFunction('Enable', () => setIsDisabled(false));
+    B.defineFunction('Disable', () => setIsDisabled(true));
     B.defineFunction('Reset', () => setChecked(componentChecked === 'true'));
 
     useEffect(() => {
@@ -109,7 +111,7 @@
       onInvalid: invalidHandler,
       onChange: handleChange,
       name: nameAttributeValue || customModelAttributeName,
-      disabled,
+      disabled: isDisabled,
       size,
       tabIndex: isDev ? -1 : undefined,
       value: 'on',


### PR DESCRIPTION
Use case: 
In my application I want to conditionally enable a checkbox component based on the role of the current user. The checkbox should be disabled by default, but I want to trigger the Enable component function via a conditional component when the user has role X (there are also other interactions triggered by this conditional). The Enable/Disable component functions can currently only be used together with for example the Button and TextField component.

There is currently a workaround where you will have to place two different checkbox components and two parent conditional components on the page. A single interaction in combination with a single checkbox would be a cleaner solution in my opinion.