### PR TITLE
Feat/spellcheck user input page 1409

### DIFF
--- a/src/components/textField.js
+++ b/src/components/textField.js
@@ -7,6 +7,7 @@
     const {
       autoComplete,
       disabled,
+      spellCheck,
       error,
       multiline,
       rows,
@@ -304,6 +305,7 @@
             min: validMinvalue,
             max: validMaxvalue,
             tabIndex: isDev ? -1 : undefined,
+            spellCheck,
           }}
           data-component={dataComponentAttributeValue}
         />

--- a/src/prefabs/textArea.js
+++ b/src/prefabs/textArea.js
@@ -122,6 +122,12 @@
           },
         },
         {
+          value: true,
+          label: 'Spellcheck',
+          key: 'spellCheck',
+          type: 'TOGGLE',
+        },
+        {
           value: false,
           label: 'Disabled',
           key: 'disabled',

--- a/src/prefabs/textField.js
+++ b/src/prefabs/textField.js
@@ -17,12 +17,6 @@
           },
         },
         {
-          value: true,
-          label: 'Autocomplete',
-          key: 'autoComplete',
-          type: 'TOGGLE',
-        },
-        {
           value: false,
           label: 'Validation options',
           key: 'validationOptions',
@@ -126,6 +120,18 @@
               value: true,
             },
           },
+        },
+        {
+          value: true,
+          label: 'Spellcheck',
+          key: 'spellCheck',
+          type: 'TOGGLE',
+        },
+        {
+          value: true,
+          label: 'Autocomplete',
+          key: 'autoComplete',
+          type: 'TOGGLE',
         },
         {
           type: 'TOGGLE',


### PR DESCRIPTION
feat: spellcheck attribute can be configured
- When the builder adds the text input (text + multiline) on the canvas they have spellcheck enabled by default
- The builder is able to turn off the spell check



https://bettyblocks.atlassian.net/browse/PAGE-1409

**Goal**
As a builder, I want to be able to configure that the text inputs of my application do a spell check, so that my endusers get feedback when they making spelling mistakes.

**Acc req**

- When the builder adds the text input (text + multiline) on the canvas they have spellcheck enabled by default
- The builder is able to turn off the spell check
- The spell check is default browser behaviour so uses the browser language

