### PR TITLE
Feat/autocomplete empty label page 1280

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# [1.194.0](https://github.com/bettyblocks/material-ui-component-set/compare/v1.193.0...v1.194.0) (2021-12-29)
+
+
+### Bug Fixes
+
+* add button on canvas due to wrong option index ([7e4f616](https://github.com/bettyblocks/material-ui-component-set/commit/7e4f6162d722669023930135ba641b118734b6f7))
+* group duplicate props ([e56363a](https://github.com/bettyblocks/material-ui-component-set/commit/e56363a650fc1693b91aa38b3f5fcb961da7fa36))
+
+
+### Features
+
+* open internal page in new tab ([405f794](https://github.com/bettyblocks/material-ui-component-set/commit/405f794bdfd945698a046fa7a90fb57cb211905d))
+
 # [1.193.0](https://github.com/bettyblocks/material-ui-component-set/compare/v1.192.1...v1.193.0) (2021-12-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "1.193.0",
+  "version": "1.194.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -640,7 +640,7 @@
             return result[valueProp.name] === value[valueProp.name];
           })
         ) {
-          return [value, ...results];
+          return value !== '' ? [value, ...results] : [...results];
         }
 
         return results;

--- a/src/prefabs/autoComplete.js
+++ b/src/prefabs/autoComplete.js
@@ -138,20 +138,6 @@
         },
         {
           type: 'TOGGLE',
-          label: 'Free solo',
-          key: 'freeSolo',
-          value: false,
-          configuration: {
-            condition: {
-              type: 'SHOW',
-              option: 'optionType',
-              comparator: 'EQ',
-              value: 'model',
-            },
-          },
-        },
-        {
-          type: 'TOGGLE',
           label: 'Allow multiple values',
           key: 'multiple',
           value: false,


### PR DESCRIPTION
Builders are using the "freesolo" option just to remove the "--empty--" option that is being displayed for the single value autocomplete. 

Also removed the "freesolo" option as it was unclear what it was used for and adds a lot of complexity 