### PR TITLE
fix: prevent empty option based on the default prefab empty string

### DIFF
--- a/src/components/autoComplete.js
+++ b/src/components/autoComplete.js
@@ -640,7 +640,7 @@
             return result[valueProp.name] === value[valueProp.name];
           })
         ) {
-          return [value, ...results];
+          return value !== '' ? [value, ...results] : [...results];
         }
 
         return results;

--- a/src/prefabs/autoComplete.js
+++ b/src/prefabs/autoComplete.js
@@ -138,20 +138,6 @@
         },
         {
           type: 'TOGGLE',
-          label: 'Free solo',
-          key: 'freeSolo',
-          value: false,
-          configuration: {
-            condition: {
-              type: 'SHOW',
-              option: 'optionType',
-              comparator: 'EQ',
-              value: 'model',
-            },
-          },
-        },
-        {
-          type: 'TOGGLE',
           label: 'Allow multiple values',
           key: 'multiple',
           value: false,


### PR DESCRIPTION
Builders are using the "freesolo" option just to remove the "--empty--" option that is being displayed for the single value autocomplete.

Also removed the "freesolo" option as it was unclear what it was used for and adds a lot of complexity