### PR TITLE
fix: DateTimePicker breaks on keyboard input

### DIFF
--- a/src/components/dateTimePicker.js
+++ b/src/components/dateTimePicker.js
@@ -91,8 +91,18 @@
         let datevalue = selectedDate;
         if (type === 'date') {
           datevalue = convertToDate(selectedDate);
+          B.triggerEvent('onChange', datevalue);
+          return;
         }
-        B.triggerEvent('onChange', datevalue);
+
+        if (!datevalue) {
+          B.triggerEvent('onChange', '');
+          return;
+        }
+
+        if (DateFns.isValid(datevalue)) {
+          B.triggerEvent('onChange', datevalue);
+        }
       }
     }, [selectedDate]);
 


### PR DESCRIPTION
 - onChange event is only sent on valid or empty input