### PR TITLE
chore: move cursor property to customStyles

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -338,6 +338,7 @@
           ...style['&:active'],
         },
         ...style,
+        cursor: 'pointer',
       }),
       linkComponent: {
         '&, &.MuiTypography-root': {
@@ -473,7 +474,6 @@
         boxSizing: 'border-box',
         display: 'flex',
         width: '100%',
-        cursor: 'pointer',
         justifyContent: 'center',
         alignItems: 'center',
       },


### PR DESCRIPTION
This fixes the cursor to change to 'pointer' when hovering over the entire button, not just the text.