### PR TITLE
feat: add show development step option

### DIFF
--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -16,7 +16,7 @@
     const { env, useText, Children, Icon } = B;
     const {
       activeStep: stepIndex,
-      activeDevelopmentStep,
+      selectedDesignStepIndex,
       variant,
       type,
       alternativeLabel,
@@ -28,7 +28,7 @@
 
     const isDev = env === 'dev';
     const isEmpty = children.length === 0;
-    const currentStep = isDev ? activeDevelopmentStep : stepIndex;
+    const currentStep = isDev ? selectedDesignStepIndex : stepIndex;
     const activeStepIndex = parseInt(currentStep - 1, 10) || 0;
     const [activeStep, setActiveStep] = useState(activeStepIndex);
     const buttonNextText = useText(buttonNext);

--- a/src/prefabs/stepper.js
+++ b/src/prefabs/stepper.js
@@ -15,8 +15,8 @@
         },
         {
           type: 'NUMBER',
-          label: 'Show development step',
-          key: 'activeDevelopmentStep',
+          label: 'Selected design step index',
+          key: 'selectedDesignStepIndex',
           value: '1',
         },
         {


### PR DESCRIPTION
Example: 
Your steps component has 5 steps. Step 1 opens on page load, but you got feedback on step 3.

Current situation: 
1. Navigate to steps component en set the 'Show step' on step 3.
2. Make changes on step 3
3. Navigate to steps component en set the 'Show step' on step 1. (This step is comon to forget, so after you merge it to the next environment you'll receive feedback that the steps component opens on step 3 instead on step 1)
4. Compile page
5. Click on step 3 en test your changes

New situation:
1. Navigate to steps component en set the 'Show development step' on step 3.
2. Make changes on step 3
3. Compile page
4. Click on step 3 en test your changes

The new situation improves the development speed, the developer happiness and les unnecessary feedback.