### PR TITLE
Feat/add development tab option pfr 475

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -8,7 +8,7 @@
     const { Children, env, useText, Icon } = B;
     const {
       defaultValue,
-      defaultDevelopmentValue,
+      selectedDesignTabIndex,
       variant,
       centered,
       scrollButtons,
@@ -22,7 +22,7 @@
     const orientation =
       alignment === 'top' || alignment === 'bottom' ? 'horizontal' : 'vertical';
     const isDev = env === 'dev';
-    const currentTab = isDev ? defaultDevelopmentValue : defaultValue;
+    const currentTab = isDev ? selectedDesignTabIndex : defaultValue;
     const [value, setValue] = useState(parseInt(currentTab - 1, 10) || 0);
     const [tabData, setTabData] = useState({});
     const [activeTabs, setActiveTabs] = useState([value]);

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -8,6 +8,7 @@
     const { Children, env, useText, Icon } = B;
     const {
       defaultValue,
+      defaultDevelopmentValue,
       variant,
       centered,
       scrollButtons,
@@ -21,10 +22,10 @@
     const orientation =
       alignment === 'top' || alignment === 'bottom' ? 'horizontal' : 'vertical';
     const isDev = env === 'dev';
-    const [value, setValue] = useState(parseInt(defaultValue - 1, 10) || 0);
+    const currentTab = isDev ? defaultDevelopmentValue : defaultValue;
+    const [value, setValue] = useState(parseInt(currentTab - 1, 10) || 0);
     const [tabData, setTabData] = useState({});
     const [activeTabs, setActiveTabs] = useState([value]);
-
     const handleChange = (_, newValue) => {
       setValue(newValue);
       if (!activeTabs.includes(newValue)) {
@@ -39,9 +40,9 @@
     };
     useEffect(() => {
       if (isDev) {
-        setValue(parseInt(defaultValue - 1, 10));
+        setValue(parseInt(currentTab - 1, 10));
       }
-    }, [isDev, defaultValue]);
+    }, [isDev, currentTab]);
 
     const TabsHeader = (
       <Tabs

--- a/src/prefabs/tabs.js
+++ b/src/prefabs/tabs.js
@@ -14,8 +14,8 @@
           type: 'NUMBER',
         },
         {
-          label: 'Selected development tab index',
-          key: 'defaultDevelopmentValue',
+          label: 'Selected design tab index',
+          key: 'selectedDesignTabIndex',
           value: '1',
           type: 'NUMBER',
         },

--- a/src/prefabs/tabs.js
+++ b/src/prefabs/tabs.js
@@ -14,6 +14,12 @@
           type: 'NUMBER',
         },
         {
+          label: 'Selected development tab index',
+          key: 'defaultDevelopmentValue',
+          value: '1',
+          type: 'NUMBER',
+        },
+        {
           label: 'Show all tabs',
           key: 'showAllTabs',
           value: false,


### PR DESCRIPTION
Example:
Your tabs component has 5 tabs. Tab 1 opens on page load, but you got feedback on tab 3.

Current situation:

Navigate to tabs component en set the 'Selected tab index' on tab 3.
Make changes on tab 3
Navigate to tabs component en set the 'Selected tab index' on tab 1. (This step is comon to forget, so after you merge it to the next environment you'll receive feedback that the tabs component opens on tab 3 instead on tab 1)
Compile page
Click on tab 3 en test your changes
New situation:

Navigate to tabs component en set the 'Selected development tab index' on tab 3.
Make changes on tab 3
Compile page
Click on tab 3 en test your changes
The new situation improves the development speed, the developer happiness and les unnecessary feedback.