### PR TITLE
Feat/add active development step option pfr 476

### DIFF
--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -16,7 +16,7 @@
     const { env, useText, Children, Icon } = B;
     const {
       activeStep: stepIndex,
-      activeDevelopmentStep,
+      selectedDesignStepIndex,
       variant,
       type,
       alternativeLabel,
@@ -28,7 +28,7 @@
 
     const isDev = env === 'dev';
     const isEmpty = children.length === 0;
-    const currentStep = isDev ? activeDevelopmentStep : stepIndex;
+    const currentStep = isDev ? selectedDesignStepIndex : stepIndex;
     const activeStepIndex = parseInt(currentStep - 1, 10) || 0;
     const [activeStep, setActiveStep] = useState(activeStepIndex);
     const buttonNextText = useText(buttonNext);

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -16,6 +16,7 @@
     const { env, useText, Children, Icon } = B;
     const {
       activeStep: stepIndex,
+      activeDevelopmentStep,
       variant,
       type,
       alternativeLabel,
@@ -27,7 +28,8 @@
 
     const isDev = env === 'dev';
     const isEmpty = children.length === 0;
-    const activeStepIndex = parseInt(stepIndex - 1, 10) || 0;
+    const currentStep = isDev ? activeDevelopmentStep : stepIndex;
+    const activeStepIndex = parseInt(currentStep - 1, 10) || 0;
     const [activeStep, setActiveStep] = useState(activeStepIndex);
     const buttonNextText = useText(buttonNext);
     const buttonPrevText = useText(buttonPrev);
@@ -63,9 +65,9 @@
 
     useEffect(() => {
       if (isDev) {
-        setActiveStep(parseInt(stepIndex - 1, 10));
+        setActiveStep(parseInt(currentStep - 1, 10));
       }
-    }, [isDev, stepIndex]);
+    }, [isDev, currentStep]);
 
     const StepperCmp = (
       <>

--- a/src/prefabs/stepper.js
+++ b/src/prefabs/stepper.js
@@ -15,8 +15,8 @@
         },
         {
           type: 'NUMBER',
-          label: 'Show development step',
-          key: 'activeDevelopmentStep',
+          label: 'Selected design step index',
+          key: 'selectedDesignStepIndex',
           value: '1',
         },
         {

--- a/src/prefabs/stepper.js
+++ b/src/prefabs/stepper.js
@@ -14,6 +14,12 @@
           value: '1',
         },
         {
+          type: 'NUMBER',
+          label: 'Show development step',
+          key: 'activeDevelopmentStep',
+          value: '1',
+        },
+        {
           type: 'TOGGLE',
           label: 'Show all steps',
           key: 'allSteps',


### PR DESCRIPTION
Example:
Your steps component has 5 steps. Step 1 opens on page load, but you got feedback on step 3.

Current situation:

Navigate to steps component en set the 'Show step' on step 3.
Make changes on step 3
Navigate to steps component en set the 'Show step' on step 1. (This step is comon to forget, so after you merge it to the next environment you'll receive feedback that the steps component opens on step 3 instead on step 1)
Compile page
Click on step 3 en test your changes
New situation:

Navigate to steps component en set the 'Show development step' on step 3.
Make changes on step 3
Compile page
Click on step 3 en test your changes
The new situation improves the development speed, the developer happiness and les unnecessary feedback.