### PR TITLE
Feat/disable head stepper

### DIFF
--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -24,7 +24,6 @@
       buttonNext,
       buttonPrev,
       dataComponentAttribute,
-      disableNav,
     } = options;
 
     const isDev = env === 'dev';

--- a/src/components/stepper.js
+++ b/src/components/stepper.js
@@ -24,6 +24,7 @@
       buttonNext,
       buttonPrev,
       dataComponentAttribute,
+      disableNav,
     } = options;
 
     const isDev = env === 'dev';
@@ -284,7 +285,8 @@
         },
       },
       stepButton: {
-        pointerEvents: isDev && 'none',
+        pointerEvents:
+          (({ options: { disableNav } }) => disableNav || isDev) && 'none',
       },
       mobileRoot: {
         backgroundColor: ({ options: { backgroundColor } }) => [

--- a/src/prefabs/stepper.js
+++ b/src/prefabs/stepper.js
@@ -26,6 +26,12 @@
           value: false,
         },
         {
+          type: 'TOGGLE',
+          label: 'Disable navigation',
+          key: 'disableNav',
+          value: false,
+        },
+        {
           type: 'CUSTOM',
           label: 'Type',
           key: 'type',


### PR DESCRIPTION
The stepper component currently misses the option to disable the navigation. In this way you can use it in a more flexible way. We see that a lot of self builders want to use the 'steps' on different pages (which is also better for the optimisation of the page in the IDE).