### PR TITLE
Feat/drawer init close on mobile

### DIFF
--- a/src/components/drawerBar.js
+++ b/src/components/drawerBar.js
@@ -29,33 +29,31 @@
       useTheme().breakpoints.up(breakpoint),
     );
     const activeTemporary = isTemporary || (isPersistent && !aboveBreakpoint);
-
-    // Window resize 
+    let drawerOpen = isOpen;
+    // Window resize
     function getWindowDimensions() {
       const { innerWidth: width, innerHeight: height } = window;
       return {
         width,
-        height
+        height,
       };
     }
 
     // Set dimensions state
-    const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+    const [windowDimensions, setWindowDimensions] = useState(
+      getWindowDimensions(),
+    );
     useEffect(() => {
       function handleResize() {
         setWindowDimensions(getWindowDimensions());
       }
       window.addEventListener('resize', handleResize);
     }, []);
-    // End window resize 
+    // End window resize
 
-    // Check if mobile width
-    if(windowDimensions.width <= 600){
-      if(isOpen == true){ 
-        isOpen = false;
-       }else{ 
-        isOpen = true;
-       }
+    // Check if mobile view, // We check on 600px because this is also done in the css. Take a look at -> [`@media ${mediaMinWidth(600)}`]
+    if (windowDimensions.width <= 600) {
+      drawerOpen = drawerOpen ? false : true;
     }
 
     useEffect(() => {
@@ -67,7 +65,7 @@
     const TempDrawer = (
       <Drawer
         variant={activeTemporary ? 'temporary' : 'persistent'}
-        open={isOpen}
+        open={drawerOpen}
         anchor={anchor}
         onClose={toggleDrawer}
         classes={{ paper: classes.paper }}
@@ -193,7 +191,7 @@
             getSpacing(outerSpacing[2], 'Desktop'),
           marginLeft: ({ options: { outerSpacing } }) =>
             getSpacing(outerSpacing[3], 'Desktop'),
-        }, 
+        },
       },
       paper: {
         ...staticPositioning,

--- a/src/components/drawerBar.js
+++ b/src/components/drawerBar.js
@@ -195,9 +195,6 @@
             getSpacing(outerSpacing[3], 'Desktop'),
         }, 
       },
-      MuiDrawer: {
-        visibility: 'hidden',
-      },
       paper: {
         ...staticPositioning,
         top: ['unset', '!important'],

--- a/src/components/drawerBar.js
+++ b/src/components/drawerBar.js
@@ -29,31 +29,19 @@
       useTheme().breakpoints.up(breakpoint),
     );
     const activeTemporary = isTemporary || (isPersistent && !aboveBreakpoint);
-    let drawerOpen = isOpen;
-    // Window resize
-    function getWindowDimensions() {
-      const { innerWidth: width, innerHeight: height } = window;
-      return {
-        width,
-        height,
-      };
-    }
+    let open = isOpen;
+    const [windowWidth, setWindowWidth] = useState(window.innerWidth);
+    const maxMobileWidth = 600;
 
-    // Set dimensions state
-    const [windowDimensions, setWindowDimensions] = useState(
-      getWindowDimensions(),
-    );
     useEffect(() => {
-      function handleResize() {
-        setWindowDimensions(getWindowDimensions());
-      }
-      window.addEventListener('resize', handleResize);
+      const setWidth = () => {
+        setWindowWidth(window.innerWidth);
+      };
+      window.addEventListener('resize', setWidth);
     }, []);
-    // End window resize
 
-    // Check if mobile view, // We check on 600px because this is also done in the css. Take a look at -> [`@media ${mediaMinWidth(600)}`]
-    if (windowDimensions.width <= 600) {
-      drawerOpen = drawerOpen ? false : true;
+    if (windowWidth <= maxMobileWidth) {
+      open = !isOpen;
     }
 
     useEffect(() => {
@@ -65,8 +53,7 @@
     const TempDrawer = (
       <Drawer
         variant={activeTemporary ? 'temporary' : 'persistent'}
-        open={drawerOpen}
-        anchor={anchor}
+        open={open}
         onClose={toggleDrawer}
         classes={{ paper: classes.paper }}
         ModalProps={{ keepMounted: true }}

--- a/src/components/drawerBar.js
+++ b/src/components/drawerBar.js
@@ -54,6 +54,7 @@
       <Drawer
         variant={activeTemporary ? 'temporary' : 'persistent'}
         open={open}
+        anchor={anchor}
         onClose={toggleDrawer}
         classes={{ paper: classes.paper }}
         ModalProps={{ keepMounted: true }}

--- a/src/components/drawerBar.js
+++ b/src/components/drawerBar.js
@@ -22,7 +22,6 @@
     } = parent;
     const { env, useText } = B;
     const { dataComponentAttribute } = options;
-
     const isEmpty = children.length === 0;
     const isDev = env === 'dev';
     const isPristine = isEmpty && isDev;
@@ -30,6 +29,34 @@
       useTheme().breakpoints.up(breakpoint),
     );
     const activeTemporary = isTemporary || (isPersistent && !aboveBreakpoint);
+
+    // Window resize 
+    function getWindowDimensions() {
+      const { innerWidth: width, innerHeight: height } = window;
+      return {
+        width,
+        height
+      };
+    }
+
+    // Set dimensions state
+    const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
+    useEffect(() => {
+      function handleResize() {
+        setWindowDimensions(getWindowDimensions());
+      }
+      window.addEventListener('resize', handleResize);
+    }, []);
+    // End window resize 
+
+    // Check if mobile width
+    if(windowDimensions.width <= 600){
+      if(isOpen == true){ 
+        isOpen = false;
+       }else{ 
+        isOpen = true;
+       }
+    }
 
     useEffect(() => {
       B.defineFunction('Show', openDrawer);
@@ -166,7 +193,10 @@
             getSpacing(outerSpacing[2], 'Desktop'),
           marginLeft: ({ options: { outerSpacing } }) =>
             getSpacing(outerSpacing[3], 'Desktop'),
-        },
+        }, 
+      },
+      MuiDrawer: {
+        visibility: 'hidden',
       },
       paper: {
         ...staticPositioning,


### PR DESCRIPTION
Hide the drawer sidebar on mobile, also when resizing the browser window.