### PR TITLE
Fix/trigger onchange events autocompletes

### DIFF
--- a/src/components/multi&CustomAutocomplete.js
+++ b/src/components/multi&CustomAutocomplete.js
@@ -618,6 +618,27 @@
 
     const currentValue = getValue();
 
+    useEffect(() => {
+      let triggerEventValue;
+
+      if (optionType === 'model') {
+        setDebouncedInputValue('');
+
+        if (freeSolo) {
+          triggerEventValue = currentValue || [];
+        } else {
+          triggerEventValue =
+            currentValue.length === 0
+              ? []
+              : currentValue.map((x) => x[suggestionsProp.name]);
+        }
+      } else if (optionType === 'property') {
+        triggerEventValue = currentValue || '';
+      }
+
+      B.triggerEvent('onChange', triggerEventValue, changeContext.current);
+    }, [currentValue]);
+
     // In the first render we want to make sure to convert the default value
     if (!multiple && !inputValue && currentValue) {
       setValue(currentValue);
@@ -650,29 +671,6 @@
           multiple={multiple}
           onChange={(_, newValue) => {
             setValue(newValue || (multiple ? [] : ''));
-
-            let triggerEventValue;
-
-            if (optionType === 'model') {
-              setDebouncedInputValue('');
-
-              if (freeSolo) {
-                triggerEventValue = newValue || [];
-              } else {
-                triggerEventValue =
-                  newValue.length === 0
-                    ? []
-                    : newValue.map((x) => x[suggestionsProp.name]);
-              }
-            } else if (optionType === 'property') {
-              triggerEventValue = newValue || '';
-            }
-
-            B.triggerEvent(
-              'onChange',
-              triggerEventValue,
-              changeContext.current,
-            );
           }}
           onBlur={(event) => {
             let validation = event.target.validity;

--- a/src/components/multipleValuesAutocomplete.js
+++ b/src/components/multipleValuesAutocomplete.js
@@ -637,6 +637,22 @@
 
     const currentValue = getValue();
 
+    useEffect(() => {
+      let triggerEventValue;
+
+      if (optionType === 'model') {
+        setDebouncedInputValue('');
+        triggerEventValue =
+          currentValue.length === 0
+            ? []
+            : currentValue.map((x) => x[valueProp.name]);
+      } else if (optionType === 'property') {
+        triggerEventValue = currentValue || '';
+      }
+
+      B.triggerEvent('onChange', triggerEventValue, changeContext.current);
+    }, [currentValue]);
+
     const renderLabel = (option) => {
       let optionLabel = '';
 
@@ -670,24 +686,6 @@
           multiple={multiple}
           onChange={(_, newValue) => {
             setValue(newValue || (multiple ? [] : ''));
-
-            let triggerEventValue;
-
-            if (optionType === 'model') {
-              setDebouncedInputValue('');
-              triggerEventValue =
-                newValue.length === 0
-                  ? []
-                  : newValue.map((x) => x[valueProp.name]);
-            } else if (optionType === 'property') {
-              triggerEventValue = newValue || '';
-            }
-
-            B.triggerEvent(
-              'onChange',
-              triggerEventValue,
-              changeContext.current,
-            );
           }}
           onInputChange={(event, newValue) => {
             let validation = event ? event.target.validity : null;

--- a/src/components/multipleValuesAutocomplete.js
+++ b/src/components/multipleValuesAutocomplete.js
@@ -641,7 +641,6 @@
       let triggerEventValue;
 
       if (optionType === 'model') {
-        setDebouncedInputValue('');
         triggerEventValue =
           currentValue.length === 0
             ? []
@@ -698,10 +697,8 @@
               (event.type === 'change' || event.type === 'keydown')
             ) {
               setInputValue(newValue);
-              setDebouncedInputValue(newValue);
             } else if (event && event.type === 'click') {
               setInputValue(newValue);
-              setDebouncedInputValue(newValue);
             }
           }}
           onBlur={(event) => {

--- a/src/components/single&CustomAutocomplete.js
+++ b/src/components/single&CustomAutocomplete.js
@@ -563,6 +563,18 @@
 
     const currentValue = getValue();
 
+    useEffect(() => {
+      let triggerEventValue;
+
+      if (optionType === 'model') {
+        triggerEventValue = currentValue || '';
+      } else if (optionType === 'property') {
+        triggerEventValue = currentValue || '';
+      }
+
+      B.triggerEvent('onChange', triggerEventValue, changeContext.current);
+    }, [currentValue]);
+
     // In the first render we want to make sure to convert the default value
     if (!inputValue && currentValue) {
       setValue(currentValue);
@@ -606,20 +618,6 @@
           }}
           onChange={(_, newValue) => {
             setValue(newValue || '');
-
-            let triggerEventValue;
-
-            if (optionType === 'model') {
-              triggerEventValue = newValue || '';
-            } else if (optionType === 'property') {
-              triggerEventValue = newValue || '';
-            }
-
-            B.triggerEvent(
-              'onChange',
-              triggerEventValue,
-              changeContext.current,
-            );
           }}
           onInputChange={(event, newValue) => {
             if (

--- a/src/components/singleValueAutocomplete.js
+++ b/src/components/singleValueAutocomplete.js
@@ -606,6 +606,17 @@
 
     const currentValue = getValue();
 
+    useEffect(() => {
+      let triggerEventValue;
+
+      if (optionType === 'model') {
+        triggerEventValue = currentValue ? currentValue[valueProp.name] : '';
+      } else if (optionType === 'property') {
+        triggerEventValue = currentValue || '';
+      }
+      B.triggerEvent('onChange', triggerEventValue, changeContext.current);
+    }, [currentValue]);
+
     // In the first render we want to make sure to convert the default value
     if (!inputValue && currentValue) {
       setValue(currentValue);
@@ -644,20 +655,6 @@
           loading={loading}
           onChange={(_, newValue) => {
             setValue(newValue || '');
-
-            let triggerEventValue;
-
-            if (optionType === 'model') {
-              triggerEventValue = newValue ? newValue[valueProp.name] : '';
-            } else if (optionType === 'property') {
-              triggerEventValue = newValue || '';
-            }
-
-            B.triggerEvent(
-              'onChange',
-              triggerEventValue,
-              changeContext.current,
-            );
           }}
           onInputChange={(event, newValue) => {
             let validation = event ? event.target.validity : null;


### PR DESCRIPTION
This change will trigger the onChange event even when the value is changed from outside the autocomplete components. One way you can use this is to use interactions in order to change the value of an autocomplete, like shown on this demo page: https://roy-consultancy.betty.app/set-autocomplete-value

Here on the left you see the current version which does not trigger the onChange event even though the value of the autocomplete is changed, on the right is the updated version where the onChange is always triggered when the value of the component is changed.

We need this change for Houthoff, a legal client in PDS.

There was a issue with the filtering in the the multiple value autocomplete, that is solved by removing unnecessary debounce state changes.