### PR TITLE
Drawer component mobile visibility

### DIFF
--- a/src/components/drawer.js
+++ b/src/components/drawer.js
@@ -5,6 +5,7 @@
   orientation: 'HORIZONTAL',
   jsx: (() => {
     const { Children, env, useText } = B;
+    const { useMediaQuery, useTheme } = window.MaterialUI.Core;
     const isEmpty = children.length === 0;
     const isPristine = isEmpty && env === 'dev';
     const {
@@ -14,8 +15,13 @@
       temporaryAnchor,
       breakpoint,
       visibility,
+      responsiveVisibility,
       dataComponentAttribute,
     } = options;
+
+    const downBreakpoint = useMediaQuery(
+      useTheme().breakpoints.down(breakpoint),
+    );
 
     const isTemporary = drawerType === 'temporary';
     const anchor = isTemporary ? temporaryAnchor : persistentAnchor;
@@ -27,8 +33,12 @@
     const toggleDrawer = () => setIsOpen((s) => !s);
 
     useEffect(() => {
-      setIsOpen(visibility);
-    }, [visibility]);
+      if (downBreakpoint) {
+        setIsOpen(responsiveVisibility);
+      } else {
+        setIsOpen(visibility);
+      }
+    }, [visibility, responsiveVisibility, downBreakpoint]);
 
     return (
       <div

--- a/src/prefabs/structures/Drawer/options/index.ts
+++ b/src/prefabs/structures/Drawer/options/index.ts
@@ -75,6 +75,12 @@ export const options = {
       as: 'VISIBILITY',
     },
   }),
+  responsiveVisibility: toggle('Toggle responsive visibility', {
+    value: true,
+    configuration: {
+      as: 'VISIBILITY',
+    },
+  }),
 
   ...advanced,
 };


### PR DESCRIPTION
When using the drawer component you can chose “Persistant” or “Temporary” mode and then you can chose a breakpoint on which you want the sidebar to be “Temporary”. When it is persistant you want it to be shown so the visibility is set to true. On mobile, when it’s temporary you need to have a separate possibility to set the default visibility. The most obvious choice is that it’s closed by default. 

I added an extra option “Toggle responsive visibility” to the component.

I also needed this feature in a use case (availability planning app). This app will be used a lot on mobile devices and it will also become a template.