### PR TITLE
Ci/allow publish action dispatch from GitHub page 1337

### DIFF
--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -1,6 +1,7 @@
 name: Publish component set on production
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.27.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.26.0...v2.27.0) (2022-08-17)
+
+
+### Features
+
+* replaced setOption in column layout TMPLT-1653 ([14e3403](https://github.com/bettyblocks/material-ui-component-set/commit/14e3403395523a6676c5a230f68274a7f06a137c))
+
 # [2.26.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.25.0...v2.26.0) (2022-08-12)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.26.0",
+  "version": "2.27.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,


### PR DESCRIPTION
This adds a button to the GitHub interface and allows the production publish workflow to be run manually.
I made the PR because of an issue we came across today and we thought we would need it, but it wasn't necessary in the end. Still it couldn't hurt to have!

![Screenshot from 2022-08-18 11-15-58](https://user-images.githubusercontent.com/78550663/185358808-a1e817b0-4980-4181-a4aa-beb53f74ba30.png)
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

Let me know if you guys agree :)
