### PR TITLE
Feat/page variables in hidden input page 2064

### DIFF
--- a/src/components/actionJSHiddenInput.js
+++ b/src/components/actionJSHiddenInput.js
@@ -11,13 +11,11 @@
       return <div className={classes.dev}>Hidden input</div>;
     }
 
-    const valueProperty = B.useProperty(value);
-
     function Input() {
       return (
         <input
           className={[isDev ? classes.dev : ''].join(' ')}
-          defaultValue={parseInt(valueProperty, 10)}
+          defaultValue={B.useText(value)}
           id={name}
           name={name}
           type="hidden"

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -46,7 +46,6 @@ const beforeCreate = ({
       close={close}
       prefab={originalPrefab}
       save={save}
-      skip
     />
   );
 };

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -46,6 +46,7 @@ const beforeCreate = ({
       close={close}
       prefab={originalPrefab}
       save={save}
+      skip
     />
   );
 };

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -3,7 +3,7 @@ import {
   prefab,
   component,
   option,
-  property,
+  variable,
   Icon,
   BeforeCreateArgs,
 } from '@betty-blocks/component-sdk';
@@ -57,7 +57,7 @@ const attributes = {
 
 const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', { label: 'Name', value: '' }),
-  value: property('Value'),
+  value: variable('Value'),
 };
 
 const hooks = {


### PR DESCRIPTION
Use a variable selector instead of a property selector for the beta hidden input, allowing the user to select an input variable or a property as a value.