### PR TITLE
Fix(PAGE-2170): Remove afterDelete 'deleteActionVariable' from components.

### DIFF
--- a/src/prefabs/checkboxinput.tsx
+++ b/src/prefabs/checkboxinput.tsx
@@ -15,7 +15,6 @@ import {
   ThemeColor,
 } from '@betty-blocks/component-sdk';
 
-import { deleteActionVariable } from './hooks/deleteActionVariable';
 
 const beforeCreate = ({
   close,
@@ -148,7 +147,7 @@ const options = {
 };
 
 const hooks = {
-  $afterDelete: [deleteActionVariable],
+  $afterDelete: [],
 };
 
 export default prefab('Checkbox Beta', attributes, beforeCreate, [

--- a/src/prefabs/checkboxinput.tsx
+++ b/src/prefabs/checkboxinput.tsx
@@ -15,7 +15,6 @@ import {
   ThemeColor,
 } from '@betty-blocks/component-sdk';
 
-
 const beforeCreate = ({
   close,
   components: { CreateFormInputWizard },
@@ -146,14 +145,6 @@ const options = {
   }),
 };
 
-const hooks = {
-  $afterDelete: [],
-};
-
 export default prefab('Checkbox Beta', attributes, beforeCreate, [
-  component(
-    'CheckboxInput',
-    { label: 'Checkbox input Beta', options, ...hooks },
-    [],
-  ),
+  component('CheckboxInput', { label: 'Checkbox input Beta', options }, []),
 ]);

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -8,8 +8,6 @@ import {
   BeforeCreateArgs,
 } from '@betty-blocks/component-sdk';
 
-import { deleteActionVariable } from './hooks/deleteActionVariable';
-
 const beforeCreate = ({
   close,
   components: { CreateFormInputWizard },
@@ -60,9 +58,7 @@ const options = {
   value: variable('Value'),
 };
 
-const hooks = {
-  $afterDelete: [deleteActionVariable],
-};
+const hooks = { };
 
 export default prefab('Hidden Beta', attributes, beforeCreate, [
   component('Hidden Input Beta', { options, ...hooks }, []),

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -58,7 +58,7 @@ const options = {
   value: variable('Value'),
 };
 
-const hooks = { };
+const hooks = {};
 
 export default prefab('Hidden Beta', attributes, beforeCreate, [
   component('Hidden Input Beta', { options, ...hooks }, []),

--- a/src/prefabs/structures/AutocompleteInput/index.ts
+++ b/src/prefabs/structures/AutocompleteInput/index.ts
@@ -1,10 +1,9 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { updateOption } from '../../../utils';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const AutocompleteInput = (
   config: Configuration,

--- a/src/prefabs/structures/AutocompleteInput/index.ts
+++ b/src/prefabs/structures/AutocompleteInput/index.ts
@@ -3,8 +3,6 @@ import { updateOption } from '../../../utils';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [];
-
 export const AutocompleteInput = (
   config: Configuration,
   descendants: PrefabReference[] = [],
@@ -30,7 +28,7 @@ export const AutocompleteInput = (
 
   return component(
     'AutocompleteInput',
-    { options, $afterDelete, style, ref, label },
+    { options, style, ref, label },
     descendants,
   );
 };

--- a/src/prefabs/structures/DateTimePicker/index.ts
+++ b/src/prefabs/structures/DateTimePicker/index.ts
@@ -9,8 +9,6 @@ export enum DateInputTypes {
   TIME = 'time',
 }
 
-const $afterDelete = [];
-
 export const DateTimePicker = (
   config: Configuration,
   descendants: PrefabReference[] = [],
@@ -61,7 +59,7 @@ export const DateTimePicker = (
 
   return component(
     'DateTimePickerInput',
-    { options, style, ref, label, $afterDelete },
+    { options, style, ref, label },
     descendants,
   );
 };

--- a/src/prefabs/structures/DateTimePicker/index.ts
+++ b/src/prefabs/structures/DateTimePicker/index.ts
@@ -1,6 +1,5 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { updateOption } from '../../../utils';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
@@ -10,7 +9,7 @@ export enum DateInputTypes {
   TIME = 'time',
 }
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const DateTimePicker = (
   config: Configuration,

--- a/src/prefabs/structures/MultiAutoCompleteInput/index.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/index.ts
@@ -3,8 +3,6 @@ import { updateOption } from '../../../utils';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [];
-
 export const MultiAutocomplete = (
   config: Configuration,
   descendants: PrefabReference[] = [],
@@ -26,7 +24,7 @@ export const MultiAutocomplete = (
 
   return component(
     'Multi Autocomplete Beta',
-    { options, $afterDelete, style, ref, label },
+    { options, style, ref, label },
     descendants,
   );
 };

--- a/src/prefabs/structures/MultiAutoCompleteInput/index.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/index.ts
@@ -1,10 +1,9 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { updateOption } from '../../../utils';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const MultiAutocomplete = (
   config: Configuration,

--- a/src/prefabs/structures/RadioInput/index.ts
+++ b/src/prefabs/structures/RadioInput/index.ts
@@ -1,9 +1,8 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const RadioInput = (
   config: Configuration,

--- a/src/prefabs/structures/RadioInput/index.ts
+++ b/src/prefabs/structures/RadioInput/index.ts
@@ -2,8 +2,6 @@ import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [];
-
 export const RadioInput = (
   config: Configuration,
   children: PrefabReference[] = [],
@@ -13,9 +11,5 @@ export const RadioInput = (
   const ref = config.ref ? { ...config.ref } : undefined;
   const label = config.label ? config.label : undefined;
 
-  return component(
-    'RadioInput',
-    { options, $afterDelete, style, ref, label },
-    children,
-  );
+  return component('RadioInput', { options, style, ref, label }, children);
 };

--- a/src/prefabs/structures/SelectInput/index.ts
+++ b/src/prefabs/structures/SelectInput/index.ts
@@ -2,8 +2,6 @@ import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [];
-
 export const SelectInput = (
   config: Configuration,
   children: PrefabReference[] = [],
@@ -13,9 +11,5 @@ export const SelectInput = (
   const ref = config.ref ? { ...config.ref } : undefined;
   const label = config.label ? config.label : undefined;
 
-  return component(
-    'SelectInput',
-    { options, $afterDelete, style, ref, label },
-    children,
-  );
+  return component('SelectInput', { options, style, ref, label }, children);
 };

--- a/src/prefabs/structures/SelectInput/index.ts
+++ b/src/prefabs/structures/SelectInput/index.ts
@@ -1,9 +1,8 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const SelectInput = (
   config: Configuration,

--- a/src/prefabs/structures/TextInput/index.ts
+++ b/src/prefabs/structures/TextInput/index.ts
@@ -3,8 +3,6 @@ import { updateOption } from '../../../utils';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [];
-
 export const TextInput = (
   config: Configuration,
   children: PrefabReference[] = [],
@@ -44,7 +42,7 @@ export const TextInput = (
 
   return component(
     'TextInput',
-    { label: config.label, options, ref, $afterDelete },
+    { label: config.label, options, ref },
     children,
   );
 };

--- a/src/prefabs/structures/TextInput/index.ts
+++ b/src/prefabs/structures/TextInput/index.ts
@@ -1,10 +1,9 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { updateOption } from '../../../utils';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { options as defaults } from './options';
 
-const $afterDelete = [deleteActionVariable];
+const $afterDelete = [];
 
 export const TextInput = (
   config: Configuration,


### PR DESCRIPTION


Components that have been duplicated, by duplicate-page for example,
point to the original ActionVariable, instead of the duplicate
ActionVariable. Meaning that after delete, a mutation to the MetaAPI is
been made to delete the wrong actionVariable.

This commit removes the afterDelete deleteActionVariable from the
components.

In the MetaAPI, we have applied changes - with the same jira-tag:
PAGE-2170 - which changed the logic of deleting an component. Now, when
you delete a component, and the component points to an actionVariable,
it will also delete the actionVariable. The actionVariableId used in the
MetaAPI points to the correct actionVariable: the duplicated one.