### PR TITLE
Fix/beta multi autocomplete broken page 2221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.45.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.44.0...v2.45.0) (2022-09-09)
+
+
+### Features
+
+* non model based form ([7471bc6](https://github.com/bettyblocks/material-ui-component-set/commit/7471bc650f1acad380897db6632467f6bc1662ec))
+
 # [2.44.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.43.0...v2.44.0) (2022-09-08)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.44.0",
+  "version": "2.45.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/prefabs/createForm.tsx
+++ b/src/prefabs/createForm.tsx
@@ -130,6 +130,7 @@ const beforeCreate = ({
                     property,
                     variable,
                     result.relatedIdProperties,
+                    result.relatedModelIds,
                   ),
                 );
                 break;

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -231,6 +231,7 @@ const beforeCreate = ({
                       property,
                       variable,
                       result.relatedIdProperties,
+                      result.relatedModelIds,
                     ),
                   );
                   break;

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -367,6 +367,7 @@ const beforeCreate = ({
                     property,
                     variable,
                     result.relatedIdProperties,
+                    result.relatedModelIds,
                   ),
                 );
                 break;


### PR DESCRIPTION
When a user adds a relational property to a form through the before create modal of a beta form, the model of the selected property needs to be filled in the model option of the component.