### PR TITLE
feat(PAGE-2238): Add permission & authProfId args to prepareAction fn.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,476 +24,415 @@
 
 # [2.56.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.56.0) (2022-09-22)
 
-
 ### Bug Fixes
 
-* decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
-* fix the datalist ([bcc6f01](https://github.com/bettyblocks/material-ui-component-set/commit/bcc6f01a3452e4073875036f16c96b4daa4ea90d))
-* remove unused var ([ff41513](https://github.com/bettyblocks/material-ui-component-set/commit/ff41513c06f8208222a35e285d19e13c07b6ef2e))
-* trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
-
+- decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
+- fix the datalist ([bcc6f01](https://github.com/bettyblocks/material-ui-component-set/commit/bcc6f01a3452e4073875036f16c96b4daa4ea90d))
+- remove unused var ([ff41513](https://github.com/bettyblocks/material-ui-component-set/commit/ff41513c06f8208222a35e285d19e13c07b6ef2e))
+- trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
 
 ### Features
 
-* add checkbox tsx page ([3220ce8](https://github.com/bettyblocks/material-ui-component-set/commit/3220ce852d50750615b3816318ad49025fd18015))
-* add checklist template ([7342aa3](https://github.com/bettyblocks/material-ui-component-set/commit/7342aa37953e31166a4511242e6e029b9fc7a509))
-* add checklist template ([166da2f](https://github.com/bettyblocks/material-ui-component-set/commit/166da2f3bef81b60d386d597df2eeba6ef8428a7))
-* add datalist ([cb3a9b3](https://github.com/bettyblocks/material-ui-component-set/commit/cb3a9b39ad858ca2d4951b09b7c7dbb2be40fc30))
+- add checkbox tsx page ([3220ce8](https://github.com/bettyblocks/material-ui-component-set/commit/3220ce852d50750615b3816318ad49025fd18015))
+- add checklist template ([7342aa3](https://github.com/bettyblocks/material-ui-component-set/commit/7342aa37953e31166a4511242e6e029b9fc7a509))
+- add checklist template ([166da2f](https://github.com/bettyblocks/material-ui-component-set/commit/166da2f3bef81b60d386d597df2eeba6ef8428a7))
+- add datalist ([cb3a9b3](https://github.com/bettyblocks/material-ui-component-set/commit/cb3a9b39ad858ca2d4951b09b7c7dbb2be40fc30))
 
 ## [2.55.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.55.3) (2022-09-22)
 
-
 ### Bug Fixes
 
-* decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
-* trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
+- decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
+- trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
 
 ## [2.55.2](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.1...v2.55.2) (2022-09-20)
 
-
 ### Bug Fixes
 
-* add take to useAllQuery ([5f35347](https://github.com/bettyblocks/material-ui-component-set/commit/5f35347ed24e8cdb2a30a6c6ea02ac899e25a8f5))
+- add take to useAllQuery ([5f35347](https://github.com/bettyblocks/material-ui-component-set/commit/5f35347ed24e8cdb2a30a6c6ea02ac899e25a8f5))
 
 ## [2.55.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.0...v2.55.1) (2022-09-16)
 
-
 ### Bug Fixes
 
-* remove property input from media component ([d9faeec](https://github.com/bettyblocks/material-ui-component-set/commit/d9faeecf7174492aefa9fa59b1ce320ffba8b512))
+- remove property input from media component ([d9faeec](https://github.com/bettyblocks/material-ui-component-set/commit/d9faeecf7174492aefa9fa59b1ce320ffba8b512))
 
 # [2.55.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.54.1...v2.55.0) (2022-09-16)
 
-
 ### Features
 
-* add correct type script ([a9930aa](https://github.com/bettyblocks/material-ui-component-set/commit/a9930aaf51f8d8c7e35e2b2a7fb43acbea04042f))
-* resolved typing in overview with detail template ([6514c48](https://github.com/bettyblocks/material-ui-component-set/commit/6514c48bd0f3f297d3a4633fbf70a61b5ea47375))
-* resolved typing in register page template ([c4e83ca](https://github.com/bettyblocks/material-ui-component-set/commit/c4e83ca3e77a8287aa7bd10300782a3fedfb353e))
+- add correct type script ([a9930aa](https://github.com/bettyblocks/material-ui-component-set/commit/a9930aaf51f8d8c7e35e2b2a7fb43acbea04042f))
+- resolved typing in overview with detail template ([6514c48](https://github.com/bettyblocks/material-ui-component-set/commit/6514c48bd0f3f297d3a4633fbf70a61b5ea47375))
+- resolved typing in register page template ([c4e83ca](https://github.com/bettyblocks/material-ui-component-set/commit/c4e83ca3e77a8287aa7bd10300782a3fedfb353e))
 
 ## [2.54.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.54.0...v2.54.1) (2022-09-13)
 
-
 ### Bug Fixes
 
-* create form querying data ([c3298a0](https://github.com/bettyblocks/material-ui-component-set/commit/c3298a00fe1c6d7f5224c0c534b10ff5f4ebb9ad))
+- create form querying data ([c3298a0](https://github.com/bettyblocks/material-ui-component-set/commit/c3298a00fe1c6d7f5224c0c534b10ff5f4ebb9ad))
 
 # [2.54.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.53.0...v2.54.0) (2022-09-13)
 
-
 ### Bug Fixes
 
-* set new placeholdertake on datatable ([a0479f1](https://github.com/bettyblocks/material-ui-component-set/commit/a0479f1ab16d768a74be4c5891214ecd54969800))
-
+- set new placeholdertake on datatable ([a0479f1](https://github.com/bettyblocks/material-ui-component-set/commit/a0479f1ab16d768a74be4c5891214ecd54969800))
 
 ### Features
 
-* add wrapper and bump cli and sdk ([78db9d4](https://github.com/bettyblocks/material-ui-component-set/commit/78db9d419db3c1372e412e5bbf1e15ff1623308d))
-* add wrapper to crud slideout ([fa65a01](https://github.com/bettyblocks/material-ui-component-set/commit/fa65a016aea3f42f9c26c84c04cda6c988430f2a))
-* add wrapper with options to crud slideout ([ef50331](https://github.com/bettyblocks/material-ui-component-set/commit/ef50331faf6bef895f43a9d44bc72af48f98af68))
+- add wrapper and bump cli and sdk ([78db9d4](https://github.com/bettyblocks/material-ui-component-set/commit/78db9d419db3c1372e412e5bbf1e15ff1623308d))
+- add wrapper to crud slideout ([fa65a01](https://github.com/bettyblocks/material-ui-component-set/commit/fa65a016aea3f42f9c26c84c04cda6c988430f2a))
+- add wrapper with options to crud slideout ([ef50331](https://github.com/bettyblocks/material-ui-component-set/commit/ef50331faf6bef895f43a9d44bc72af48f98af68))
 
 # [2.53.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.52.0...v2.53.0) (2022-09-13)
 
-
 ### Features
 
-* add wrapper, remove unwanted code and bump cli + sdk ([136ed10](https://github.com/bettyblocks/material-ui-component-set/commit/136ed102f25e6e5959b18f3740c5fa384cb80df6))
+- add wrapper, remove unwanted code and bump cli + sdk ([136ed10](https://github.com/bettyblocks/material-ui-component-set/commit/136ed102f25e6e5959b18f3740c5fa384cb80df6))
 
 # [2.52.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.51.1...v2.52.0) (2022-09-13)
 
-
 ### Features
 
-* added earthly builds ([ba545bd](https://github.com/bettyblocks/material-ui-component-set/commit/ba545bd613c0907a40314ee5b506b79b92772a6c))
+- added earthly builds ([ba545bd](https://github.com/bettyblocks/material-ui-component-set/commit/ba545bd613c0907a40314ee5b506b79b92772a6c))
 
 ## [2.51.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.51.0...v2.51.1) (2022-09-13)
 
-
 ### Bug Fixes
 
-* remove warning condition for actionJS ([2846865](https://github.com/bettyblocks/material-ui-component-set/commit/2846865c8c452df385ad1107d540235f0139fbd6))
+- remove warning condition for actionJS ([2846865](https://github.com/bettyblocks/material-ui-component-set/commit/2846865c8c452df385ad1107d540235f0139fbd6))
 
 # [2.51.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.50.0...v2.51.0) (2022-09-13)
 
-
 ### Features
 
-* implement wrapper in backoffice ([6701d0a](https://github.com/bettyblocks/material-ui-component-set/commit/6701d0ad015d21ea0237c911b535ca3691f3e5f1))
+- implement wrapper in backoffice ([6701d0a](https://github.com/bettyblocks/material-ui-component-set/commit/6701d0ad015d21ea0237c911b535ca3691f3e5f1))
 
 # [2.50.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.49.0...v2.50.0) (2022-09-13)
 
-
 ### Bug Fixes
 
-* update beforecreate and bump cli and sdk ([eeec180](https://github.com/bettyblocks/material-ui-component-set/commit/eeec180ba688decd7b879176c63f2075f225d3aa))
-
+- update beforecreate and bump cli and sdk ([eeec180](https://github.com/bettyblocks/material-ui-component-set/commit/eeec180ba688decd7b879176c63f2075f225d3aa))
 
 ### Features
 
-* implement wrapper in card and list view templates ([a908305](https://github.com/bettyblocks/material-ui-component-set/commit/a908305ed2dcca8291725216e4c6d31f7e3a150e))
+- implement wrapper in card and list view templates ([a908305](https://github.com/bettyblocks/material-ui-component-set/commit/a908305ed2dcca8291725216e4c6d31f7e3a150e))
 
 # [2.49.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.48.0...v2.49.0) (2022-09-12)
 
-
 ### Features
 
-* add separator option to decimal input ([4c02cc1](https://github.com/bettyblocks/material-ui-component-set/commit/4c02cc124ce0846fc41bc37d36cbf5332639e487))
+- add separator option to decimal input ([4c02cc1](https://github.com/bettyblocks/material-ui-component-set/commit/4c02cc124ce0846fc41bc37d36cbf5332639e487))
 
 # [2.48.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.47.1...v2.48.0) (2022-09-12)
 
-
 ### Features
 
-* implemented wrapper in profile page template TMPLT-1601 ([adc7ba0](https://github.com/bettyblocks/material-ui-component-set/commit/adc7ba03266afc7595c8dd7762d5a75b825eacb0))
+- implemented wrapper in profile page template TMPLT-1601 ([adc7ba0](https://github.com/bettyblocks/material-ui-component-set/commit/adc7ba03266afc7595c8dd7762d5a75b825eacb0))
 
 ## [2.47.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.47.0...v2.47.1) (2022-09-12)
 
-
 ### Bug Fixes
 
-* add related model ids to bettyinput ([67aa71f](https://github.com/bettyblocks/material-ui-component-set/commit/67aa71f9399779d3eb581e63b622fb07a4abc657))
-* update component sdk ([0bef560](https://github.com/bettyblocks/material-ui-component-set/commit/0bef560e00bd22a99781edcfe516beba89b35378))
+- add related model ids to bettyinput ([67aa71f](https://github.com/bettyblocks/material-ui-component-set/commit/67aa71f9399779d3eb581e63b622fb07a4abc657))
+- update component sdk ([0bef560](https://github.com/bettyblocks/material-ui-component-set/commit/0bef560e00bd22a99781edcfe516beba89b35378))
 
 # [2.47.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.46.2...v2.47.0) (2022-09-12)
 
-
 ### Features
 
-* add wrapper to login template ([d9d5ac9](https://github.com/bettyblocks/material-ui-component-set/commit/d9d5ac92686823d44cc10f292913a58b61d03d66))
-* implemented wrapper in login and register page template ([803efa5](https://github.com/bettyblocks/material-ui-component-set/commit/803efa5044bbbb7cbe79a9035db10a84a041b1ed))
+- add wrapper to login template ([d9d5ac9](https://github.com/bettyblocks/material-ui-component-set/commit/d9d5ac92686823d44cc10f292913a58b61d03d66))
+- implemented wrapper in login and register page template ([803efa5](https://github.com/bettyblocks/material-ui-component-set/commit/803efa5044bbbb7cbe79a9035db10a84a041b1ed))
 
 ## [2.46.2](https://github.com/bettyblocks/material-ui-component-set/compare/v2.46.1...v2.46.2) (2022-09-12)
 
-
 ### Bug Fixes
 
-* placed afterDeletes back ([41535fc](https://github.com/bettyblocks/material-ui-component-set/commit/41535fcbc09b8f67b30cd13d590bdac8a09b402e))
+- placed afterDeletes back ([41535fc](https://github.com/bettyblocks/material-ui-component-set/commit/41535fcbc09b8f67b30cd13d590bdac8a09b402e))
 
 ## [2.46.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.46.0...v2.46.1) (2022-09-12)
 
-
 ### Bug Fixes
 
-* fix refetch singlevalueautocomplete ([a4ac7d1](https://github.com/bettyblocks/material-ui-component-set/commit/a4ac7d191246d319e6412bd55e39c6a2167439d2))
+- fix refetch singlevalueautocomplete ([a4ac7d1](https://github.com/bettyblocks/material-ui-component-set/commit/a4ac7d191246d319e6412bd55e39c6a2167439d2))
 
 # [2.46.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.45.0...v2.46.0) (2022-09-09)
 
-
 ### Bug Fixes
 
-* also remove margin from multiautocomplete ([c8bcc55](https://github.com/bettyblocks/material-ui-component-set/commit/c8bcc5591382394c2fa4fe130c934730f0c20168))
-* change value in the input ([5d6c406](https://github.com/bettyblocks/material-ui-component-set/commit/5d6c406462d8a56564f32f1880cd809c8b34f37a))
-* clearFileUpload should clear current upload ([9ba797a](https://github.com/bettyblocks/material-ui-component-set/commit/9ba797a522d5ed2c8a469510e1fef7ffc8366c60))
-* console warns ([e397438](https://github.com/bettyblocks/material-ui-component-set/commit/e397438a1f75d617d87da9ff5f5a5521631af1ac))
-* create file upload crash ([9898470](https://github.com/bettyblocks/material-ui-component-set/commit/9898470034e6b57c5650d4ac6e9fb6aa574e000a))
-* design time crash on property select file input ([c1f445f](https://github.com/bettyblocks/material-ui-component-set/commit/c1f445f12723e3fb690350b3205ebbead750f7bf))
-* file upload use value property ([28e39ed](https://github.com/bettyblocks/material-ui-component-set/commit/28e39ed0f063eb2faea61147bdd43f1a63e738cb))
-* remove margin from formcontrol component ([8b13ad7](https://github.com/bettyblocks/material-ui-component-set/commit/8b13ad7e10d292176b48956ea7b4533f48b9986f))
-* trigger pipelines ([1d36456](https://github.com/bettyblocks/material-ui-component-set/commit/1d364567dbd6a05cfda934feb7bf832eace5a01c))
-* update types ([8e4aeb9](https://github.com/bettyblocks/material-ui-component-set/commit/8e4aeb923a23cafc1d2609f2eeb702f84c8d13db))
-
+- also remove margin from multiautocomplete ([c8bcc55](https://github.com/bettyblocks/material-ui-component-set/commit/c8bcc5591382394c2fa4fe130c934730f0c20168))
+- change value in the input ([5d6c406](https://github.com/bettyblocks/material-ui-component-set/commit/5d6c406462d8a56564f32f1880cd809c8b34f37a))
+- clearFileUpload should clear current upload ([9ba797a](https://github.com/bettyblocks/material-ui-component-set/commit/9ba797a522d5ed2c8a469510e1fef7ffc8366c60))
+- console warns ([e397438](https://github.com/bettyblocks/material-ui-component-set/commit/e397438a1f75d617d87da9ff5f5a5521631af1ac))
+- create file upload crash ([9898470](https://github.com/bettyblocks/material-ui-component-set/commit/9898470034e6b57c5650d4ac6e9fb6aa574e000a))
+- design time crash on property select file input ([c1f445f](https://github.com/bettyblocks/material-ui-component-set/commit/c1f445f12723e3fb690350b3205ebbead750f7bf))
+- file upload use value property ([28e39ed](https://github.com/bettyblocks/material-ui-component-set/commit/28e39ed0f063eb2faea61147bdd43f1a63e738cb))
+- remove margin from formcontrol component ([8b13ad7](https://github.com/bettyblocks/material-ui-component-set/commit/8b13ad7e10d292176b48956ea7b4533f48b9986f))
+- trigger pipelines ([1d36456](https://github.com/bettyblocks/material-ui-component-set/commit/1d364567dbd6a05cfda934feb7bf832eace5a01c))
+- update types ([8e4aeb9](https://github.com/bettyblocks/material-ui-component-set/commit/8e4aeb923a23cafc1d2609f2eeb702f84c8d13db))
 
 ### Features
 
-* add input wizard to file input ([bc5208a](https://github.com/bettyblocks/material-ui-component-set/commit/bc5208af7fb47d992dab0787763f513aacefea86))
-* add interactions ([4ce8865](https://github.com/bettyblocks/material-ui-component-set/commit/4ce88657ed029b22dfeb593b845da365e1bd85e2))
-* add trigger events in fileUploadInput ([0827dc8](https://github.com/bettyblocks/material-ui-component-set/commit/0827dc825f9448bbb50c48d0a85519b29438b878))
-* added loading and pass correct file type to the helper ([e8ec4c1](https://github.com/bettyblocks/material-ui-component-set/commit/e8ec4c1ba9fbf16455a8c1869413a6ebacf49340))
-* added required and maxFileSize option ([dc4ae72](https://github.com/bettyblocks/material-ui-component-set/commit/dc4ae72ad8a7ba9ffa15af3baf715676085e0144))
-* convert file upload to tsx ([82a6b3d](https://github.com/bettyblocks/material-ui-component-set/commit/82a6b3dbc7799dfc8dd73909cb3b4f68d8864148))
-* enable file property on update form ([ec9021f](https://github.com/bettyblocks/material-ui-component-set/commit/ec9021ff162dc7c46811c0379e8733a8da5bfe1c))
-* fix file upload not sending correct property ([6b73d68](https://github.com/bettyblocks/material-ui-component-set/commit/6b73d689a81c1f667a44e80f7d29c2b8f931a161))
-* fix lint issue ([5687af9](https://github.com/bettyblocks/material-ui-component-set/commit/5687af9e78127a4a02a4bf98c28bb64011f0fcaf))
-* fix non typescript type ([7a3fdac](https://github.com/bettyblocks/material-ui-component-set/commit/7a3fdac19644294409e60b11336598b158386252))
-* show current value in file upload ([5517937](https://github.com/bettyblocks/material-ui-component-set/commit/551793782e1ad419115529c71882fbd52f7b0204))
-* validate maximum file size ([c142d6e](https://github.com/bettyblocks/material-ui-component-set/commit/c142d6eb289faad5a8e812e34376f85a17025ba9))
+- add input wizard to file input ([bc5208a](https://github.com/bettyblocks/material-ui-component-set/commit/bc5208af7fb47d992dab0787763f513aacefea86))
+- add interactions ([4ce8865](https://github.com/bettyblocks/material-ui-component-set/commit/4ce88657ed029b22dfeb593b845da365e1bd85e2))
+- add trigger events in fileUploadInput ([0827dc8](https://github.com/bettyblocks/material-ui-component-set/commit/0827dc825f9448bbb50c48d0a85519b29438b878))
+- added loading and pass correct file type to the helper ([e8ec4c1](https://github.com/bettyblocks/material-ui-component-set/commit/e8ec4c1ba9fbf16455a8c1869413a6ebacf49340))
+- added required and maxFileSize option ([dc4ae72](https://github.com/bettyblocks/material-ui-component-set/commit/dc4ae72ad8a7ba9ffa15af3baf715676085e0144))
+- convert file upload to tsx ([82a6b3d](https://github.com/bettyblocks/material-ui-component-set/commit/82a6b3dbc7799dfc8dd73909cb3b4f68d8864148))
+- enable file property on update form ([ec9021f](https://github.com/bettyblocks/material-ui-component-set/commit/ec9021ff162dc7c46811c0379e8733a8da5bfe1c))
+- fix file upload not sending correct property ([6b73d68](https://github.com/bettyblocks/material-ui-component-set/commit/6b73d689a81c1f667a44e80f7d29c2b8f931a161))
+- fix lint issue ([5687af9](https://github.com/bettyblocks/material-ui-component-set/commit/5687af9e78127a4a02a4bf98c28bb64011f0fcaf))
+- fix non typescript type ([7a3fdac](https://github.com/bettyblocks/material-ui-component-set/commit/7a3fdac19644294409e60b11336598b158386252))
+- show current value in file upload ([5517937](https://github.com/bettyblocks/material-ui-component-set/commit/551793782e1ad419115529c71882fbd52f7b0204))
+- validate maximum file size ([c142d6e](https://github.com/bettyblocks/material-ui-component-set/commit/c142d6eb289faad5a8e812e34376f85a17025ba9))
 
 ## [2.45.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.45.0...v2.45.1) (2022-09-09)
 
-
 ### Bug Fixes
 
-* also remove margin from multiautocomplete ([c8bcc55](https://github.com/bettyblocks/material-ui-component-set/commit/c8bcc5591382394c2fa4fe130c934730f0c20168))
-* remove margin from formcontrol component ([8b13ad7](https://github.com/bettyblocks/material-ui-component-set/commit/8b13ad7e10d292176b48956ea7b4533f48b9986f))
-* trigger pipelines ([1d36456](https://github.com/bettyblocks/material-ui-component-set/commit/1d364567dbd6a05cfda934feb7bf832eace5a01c))
+- also remove margin from multiautocomplete ([c8bcc55](https://github.com/bettyblocks/material-ui-component-set/commit/c8bcc5591382394c2fa4fe130c934730f0c20168))
+- remove margin from formcontrol component ([8b13ad7](https://github.com/bettyblocks/material-ui-component-set/commit/8b13ad7e10d292176b48956ea7b4533f48b9986f))
+- trigger pipelines ([1d36456](https://github.com/bettyblocks/material-ui-component-set/commit/1d364567dbd6a05cfda934feb7bf832eace5a01c))
 
 # [2.45.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.44.0...v2.45.0) (2022-09-09)
 
-
 ### Features
 
-* non model based form ([7471bc6](https://github.com/bettyblocks/material-ui-component-set/commit/7471bc650f1acad380897db6632467f6bc1662ec))
+- non model based form ([7471bc6](https://github.com/bettyblocks/material-ui-component-set/commit/7471bc650f1acad380897db6632467f6bc1662ec))
 
 # [2.44.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.43.0...v2.44.0) (2022-09-08)
 
-
 ### Bug Fixes
 
-* add default label to datepicker inputs ([d38d7c9](https://github.com/bettyblocks/material-ui-component-set/commit/d38d7c9a3fe7c2020878aaafbd8461020a544eae))
-* add fallback for actionvariable ([48ca659](https://github.com/bettyblocks/material-ui-component-set/commit/48ca65936ba5d82539887f8e66f7cc182228771e))
-* add other datepickers to allow outside a form ([32a1fb5](https://github.com/bettyblocks/material-ui-component-set/commit/32a1fb5b195ff90c6defc15a7e817c8da24c1483))
-* allow price property outside form ([15aaed2](https://github.com/bettyblocks/material-ui-component-set/commit/15aaed29486cbcada89a6d7a655cff20f824132d))
-* change label for action js variable ([44bab25](https://github.com/bettyblocks/material-ui-component-set/commit/44bab25ff44826c0c1bbf9f3624e2bee87e2f8b1))
-* datetime picker outside form ([8bba483](https://github.com/bettyblocks/material-ui-component-set/commit/8bba48372165d6e017a176a58a3b5a5a8dc9abbd))
-* remove afterDelete in hiddenInput ([f2aa360](https://github.com/bettyblocks/material-ui-component-set/commit/f2aa360da4aaac393584b9ad305bf13e7b3c5c95))
-* remove unused vars ([53fa810](https://github.com/bettyblocks/material-ui-component-set/commit/53fa81054b785a43a41a7be85b326fe9e33ee0e1))
-* retrigger pipelines ([4a39db0](https://github.com/bettyblocks/material-ui-component-set/commit/4a39db04d6e456f46276ad5d03de78ae37e1ebe6))
-* show actionjsvariable and property ([d9bd260](https://github.com/bettyblocks/material-ui-component-set/commit/d9bd26071c0a6a44caac28bdb164fa37f81d7991))
-* show correct results with a onActionSucces error ([0359dfe](https://github.com/bettyblocks/material-ui-component-set/commit/0359dfe10005b31f342abcbe81c275d66210bfc1))
-* textarea outside form ([458213f](https://github.com/bettyblocks/material-ui-component-set/commit/458213f277039f68bc5510686f49ad115395e844))
-* trigger pipelines ([171228d](https://github.com/bettyblocks/material-ui-component-set/commit/171228dfa19ec484f6becb7ec0feb74878b0858a))
-
+- add default label to datepicker inputs ([d38d7c9](https://github.com/bettyblocks/material-ui-component-set/commit/d38d7c9a3fe7c2020878aaafbd8461020a544eae))
+- add fallback for actionvariable ([48ca659](https://github.com/bettyblocks/material-ui-component-set/commit/48ca65936ba5d82539887f8e66f7cc182228771e))
+- add other datepickers to allow outside a form ([32a1fb5](https://github.com/bettyblocks/material-ui-component-set/commit/32a1fb5b195ff90c6defc15a7e817c8da24c1483))
+- allow price property outside form ([15aaed2](https://github.com/bettyblocks/material-ui-component-set/commit/15aaed29486cbcada89a6d7a655cff20f824132d))
+- change label for action js variable ([44bab25](https://github.com/bettyblocks/material-ui-component-set/commit/44bab25ff44826c0c1bbf9f3624e2bee87e2f8b1))
+- datetime picker outside form ([8bba483](https://github.com/bettyblocks/material-ui-component-set/commit/8bba48372165d6e017a176a58a3b5a5a8dc9abbd))
+- remove afterDelete in hiddenInput ([f2aa360](https://github.com/bettyblocks/material-ui-component-set/commit/f2aa360da4aaac393584b9ad305bf13e7b3c5c95))
+- remove unused vars ([53fa810](https://github.com/bettyblocks/material-ui-component-set/commit/53fa81054b785a43a41a7be85b326fe9e33ee0e1))
+- retrigger pipelines ([4a39db0](https://github.com/bettyblocks/material-ui-component-set/commit/4a39db04d6e456f46276ad5d03de78ae37e1ebe6))
+- show actionjsvariable and property ([d9bd260](https://github.com/bettyblocks/material-ui-component-set/commit/d9bd26071c0a6a44caac28bdb164fa37f81d7991))
+- show correct results with a onActionSucces error ([0359dfe](https://github.com/bettyblocks/material-ui-component-set/commit/0359dfe10005b31f342abcbe81c275d66210bfc1))
+- textarea outside form ([458213f](https://github.com/bettyblocks/material-ui-component-set/commit/458213f277039f68bc5510686f49ad115395e844))
+- trigger pipelines ([171228d](https://github.com/bettyblocks/material-ui-component-set/commit/171228dfa19ec484f6becb7ec0feb74878b0858a))
 
 ### Features
 
-* able to drag beta inputs outside form ([1f9352b](https://github.com/bettyblocks/material-ui-component-set/commit/1f9352bb260df8e8f76fe7ce558c51d2d0f0c574))
-* able to drag checkbox outside a beta form ([70de830](https://github.com/bettyblocks/material-ui-component-set/commit/70de830869dd2e1a7b887e90ee1584a69032aaaf))
+- able to drag beta inputs outside form ([1f9352b](https://github.com/bettyblocks/material-ui-component-set/commit/1f9352bb260df8e8f76fe7ce558c51d2d0f0c574))
+- able to drag checkbox outside a beta form ([70de830](https://github.com/bettyblocks/material-ui-component-set/commit/70de830869dd2e1a7b887e90ee1584a69032aaaf))
 
 # [2.43.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.42.1...v2.43.0) (2022-09-02)
 
-
 ### Features
 
-* crud with dialogs to tsx ([965b1e3](https://github.com/bettyblocks/material-ui-component-set/commit/965b1e327d9a6d74cdd9bf185c93e7c32a7cfa6c))
+- crud with dialogs to tsx ([965b1e3](https://github.com/bettyblocks/material-ui-component-set/commit/965b1e327d9a6d74cdd9bf185c93e7c32a7cfa6c))
 
 ## [2.42.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.42.0...v2.42.1) (2022-09-02)
 
-
 ### Bug Fixes
 
-* made border radius as unit again ([2b88354](https://github.com/bettyblocks/material-ui-component-set/commit/2b883541926494b1b81b52e50b1ee17890510c02))
+- made border radius as unit again ([2b88354](https://github.com/bettyblocks/material-ui-component-set/commit/2b883541926494b1b81b52e50b1ee17890510c02))
 
 # [2.42.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.41.1...v2.42.0) (2022-09-01)
 
-
 ### Bug Fixes
 
-* add notifaction to template ([8087b39](https://github.com/bettyblocks/material-ui-component-set/commit/8087b394d37069a4ee9842e89c2c15b2b887fceb))
-
+- add notifaction to template ([8087b39](https://github.com/bettyblocks/material-ui-component-set/commit/8087b394d37069a4ee9842e89c2c15b2b887fceb))
 
 ### Features
 
-* refactor login template to tsx ([0ba950e](https://github.com/bettyblocks/material-ui-component-set/commit/0ba950e5fa0827333e91595eb3a9b3b923934215))
+- refactor login template to tsx ([0ba950e](https://github.com/bettyblocks/material-ui-component-set/commit/0ba950e5fa0827333e91595eb3a9b3b923934215))
 
 ## [2.41.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.41.0...v2.41.1) (2022-09-01)
 
-
 ### Bug Fixes
 
-* single value ac triggers onload ([abc44e8](https://github.com/bettyblocks/material-ui-component-set/commit/abc44e844dd2296fc3f4c1287f3a4c639568cfab))
+- single value ac triggers onload ([abc44e8](https://github.com/bettyblocks/material-ui-component-set/commit/abc44e844dd2296fc3f4c1287f3a4c639568cfab))
 
 # [2.41.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.40.1...v2.41.0) (2022-09-01)
 
-
 ### Features
 
-* register page to tsx, update config file and update form V2 inputs ([8b247ca](https://github.com/bettyblocks/material-ui-component-set/commit/8b247ca4cadddc413db3620d5591a82542a59910))
+- register page to tsx, update config file and update form V2 inputs ([8b247ca](https://github.com/bettyblocks/material-ui-component-set/commit/8b247ca4cadddc413db3620d5591a82542a59910))
 
 ## [2.40.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.40.0...v2.40.1) (2022-09-01)
 
-
 ### Bug Fixes
 
-* icon badge color not appearing ([5a92347](https://github.com/bettyblocks/material-ui-component-set/commit/5a92347c666fda1a98a4805fd92a9a2e260f3e4b))
+- icon badge color not appearing ([5a92347](https://github.com/bettyblocks/material-ui-component-set/commit/5a92347c666fda1a98a4805fd92a9a2e260f3e4b))
 
 # [2.40.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.39.0...v2.40.0) (2022-09-01)
 
-
 ### Bug Fixes
 
-* add notifaction to template ([97a00a4](https://github.com/bettyblocks/material-ui-component-set/commit/97a00a4eb00e9a070c2dc9c328be6bd655480f33))
-
+- add notifaction to template ([97a00a4](https://github.com/bettyblocks/material-ui-component-set/commit/97a00a4eb00e9a070c2dc9c328be6bd655480f33))
 
 ### Features
 
-* crudwithslideout to tsx ([600c9b1](https://github.com/bettyblocks/material-ui-component-set/commit/600c9b1326789a2a5d72949f43976b21430eac83))
+- crudwithslideout to tsx ([600c9b1](https://github.com/bettyblocks/material-ui-component-set/commit/600c9b1326789a2a5d72949f43976b21430eac83))
 
 # [2.39.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.38.0...v2.39.0) (2022-09-01)
 
-
 ### Features
 
-* refactor error page templates to tsx TMPLT-1542 ([1943300](https://github.com/bettyblocks/material-ui-component-set/commit/19433006d5a0296979ae9c0615196078aefe8bd9))
+- refactor error page templates to tsx TMPLT-1542 ([1943300](https://github.com/bettyblocks/material-ui-component-set/commit/19433006d5a0296979ae9c0615196078aefe8bd9))
 
 # [2.38.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.37.0...v2.38.0) (2022-09-01)
 
-
 ### Features
 
-* convert template to tsx ([2f1865c](https://github.com/bettyblocks/material-ui-component-set/commit/2f1865cf5706d8bbdb33f080f821b75d2b776ac6))
+- convert template to tsx ([2f1865c](https://github.com/bettyblocks/material-ui-component-set/commit/2f1865cf5706d8bbdb33f080f821b75d2b776ac6))
 
 # [2.37.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.36.0...v2.37.0) (2022-09-01)
 
-
 ### Bug Fixes
 
-* remove unused variables ([3c84924](https://github.com/bettyblocks/material-ui-component-set/commit/3c84924a7b5ab096b225682bb0eae3d87cbc1e4c))
-* use actionJSForm ([a2bf592](https://github.com/bettyblocks/material-ui-component-set/commit/a2bf592233196be53b50d39b3f7ee64986877db7))
-* use prepare action for default beta form ([0083757](https://github.com/bettyblocks/material-ui-component-set/commit/00837573a566becf73a2658a9d59f009d99f407a))
-
+- remove unused variables ([3c84924](https://github.com/bettyblocks/material-ui-component-set/commit/3c84924a7b5ab096b225682bb0eae3d87cbc1e4c))
+- use actionJSForm ([a2bf592](https://github.com/bettyblocks/material-ui-component-set/commit/a2bf592233196be53b50d39b3f7ee64986877db7))
+- use prepare action for default beta form ([0083757](https://github.com/bettyblocks/material-ui-component-set/commit/00837573a566becf73a2658a9d59f009d99f407a))
 
 ### Features
 
-* bumped sdk ([8665be7](https://github.com/bettyblocks/material-ui-component-set/commit/8665be7040fceccb973b4b875983acefa95051fc))
+- bumped sdk ([8665be7](https://github.com/bettyblocks/material-ui-component-set/commit/8665be7040fceccb973b4b875983acefa95051fc))
 
 # [2.36.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.35.0...v2.36.0) (2022-08-31)
 
-
 ### Bug Fixes
 
-* add notifaction to template ([65eddc9](https://github.com/bettyblocks/material-ui-component-set/commit/65eddc90c7008202cf0c9eb49bc9d613f57da138))
-
+- add notifaction to template ([65eddc9](https://github.com/bettyblocks/material-ui-component-set/commit/65eddc90c7008202cf0c9eb49bc9d613f57da138))
 
 ### Features
 
-* refactor backoffice to tsx ([ff69aa1](https://github.com/bettyblocks/material-ui-component-set/commit/ff69aa1a7c3cd1563c68f140ae32d286fdaec18f))
-* refactor backoffice to tsx ([ec49744](https://github.com/bettyblocks/material-ui-component-set/commit/ec4974421bac0f4d8ef6f966daaa99f6642fdbc6))
+- refactor backoffice to tsx ([ff69aa1](https://github.com/bettyblocks/material-ui-component-set/commit/ff69aa1a7c3cd1563c68f140ae32d286fdaec18f))
+- refactor backoffice to tsx ([ec49744](https://github.com/bettyblocks/material-ui-component-set/commit/ec4974421bac0f4d8ef6f966daaa99f6642fdbc6))
 
 # [2.35.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.34.0...v2.35.0) (2022-08-30)
 
-
 ### Features
 
-* card list view to tsx, update config and update forms v2 options ([2d50e5e](https://github.com/bettyblocks/material-ui-component-set/commit/2d50e5e3c95a6d72322851a5823f796e348f82b7))
+- card list view to tsx, update config and update forms v2 options ([2d50e5e](https://github.com/bettyblocks/material-ui-component-set/commit/2d50e5e3c95a6d72322851a5823f796e348f82b7))
 
 # [2.34.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.33.0...v2.34.0) (2022-08-30)
 
-
 ### Features
 
-* card view to tsx, update config file and edit forms v2 inputs ([5162c7b](https://github.com/bettyblocks/material-ui-component-set/commit/5162c7b3198e19529a20c6a6de0e8602adef673d))
+- card view to tsx, update config file and edit forms v2 inputs ([5162c7b](https://github.com/bettyblocks/material-ui-component-set/commit/5162c7b3198e19529a20c6a6de0e8602adef673d))
 
 # [2.33.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.32.0...v2.33.0) (2022-08-30)
 
-
 ### Features
 
-* add new public file selector ([19d8050](https://github.com/bettyblocks/material-ui-component-set/commit/19d805012c636e1aec48dcfad1ef74ac681bccb0))
+- add new public file selector ([19d8050](https://github.com/bettyblocks/material-ui-component-set/commit/19d805012c636e1aec48dcfad1ef74ac681bccb0))
 
 # [2.32.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.31.1...v2.32.0) (2022-08-29)
 
-
 ### Bug Fixes
 
-* add skip param to hidden input ([360a1fb](https://github.com/bettyblocks/material-ui-component-set/commit/360a1fbf943e8f40c36f67a0e7f9994b0dac496a))
-* remove skip option from hidden input ([65647ed](https://github.com/bettyblocks/material-ui-component-set/commit/65647edc1c7688b4830faa64548936b6aa7243d5))
-
+- add skip param to hidden input ([360a1fb](https://github.com/bettyblocks/material-ui-component-set/commit/360a1fbf943e8f40c36f67a0e7f9994b0dac496a))
+- remove skip option from hidden input ([65647ed](https://github.com/bettyblocks/material-ui-component-set/commit/65647edc1c7688b4830faa64548936b6aa7243d5))
 
 ### Features
 
-* add variable selector to hidden input ([2160034](https://github.com/bettyblocks/material-ui-component-set/commit/21600343cb2d8175eb90259ce11c46d8caaaa982))
+- add variable selector to hidden input ([2160034](https://github.com/bettyblocks/material-ui-component-set/commit/21600343cb2d8175eb90259ce11c46d8caaaa982))
 
 ## [2.31.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.31.0...v2.31.1) (2022-08-29)
 
-
 ### Bug Fixes
 
-* remove default password validation ([ffccecb](https://github.com/bettyblocks/material-ui-component-set/commit/ffccecb0ee762ecf308f28be87e72585c2399d46))
+- remove default password validation ([ffccecb](https://github.com/bettyblocks/material-ui-component-set/commit/ffccecb0ee762ecf308f28be87e72585c2399d46))
 
 # [2.31.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.30.0...v2.31.0) (2022-08-29)
 
-
 ### Features
 
-* refactor inspirational dashboard to TSX TMPLT-1541 ([6d3d2f3](https://github.com/bettyblocks/material-ui-component-set/commit/6d3d2f3a123b555be216710b7aaed604e5c49de7))
+- refactor inspirational dashboard to TSX TMPLT-1541 ([6d3d2f3](https://github.com/bettyblocks/material-ui-component-set/commit/6d3d2f3a123b555be216710b7aaed604e5c49de7))
 
 # [2.30.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.29.0...v2.30.0) (2022-08-25)
 
-
 ### Features
 
-* card list view to tsx, update config, update forms v2 options ([81f6689](https://github.com/bettyblocks/material-ui-component-set/commit/81f6689d0f6fef316d4f9c6fca770f835bb4e98b))
+- card list view to tsx, update config, update forms v2 options ([81f6689](https://github.com/bettyblocks/material-ui-component-set/commit/81f6689d0f6fef316d4f9c6fca770f835bb4e98b))
 
 # [2.29.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.28.0...v2.29.0) (2022-08-24)
 
-
 ### Features
 
-* converted header and footer to tsx ([bb03686](https://github.com/bettyblocks/material-ui-component-set/commit/bb0368674f5964d05ea529649f35ab838cc24e81))
+- converted header and footer to tsx ([bb03686](https://github.com/bettyblocks/material-ui-component-set/commit/bb0368674f5964d05ea529649f35ab838cc24e81))
 
 # [2.28.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.27.0...v2.28.0) (2022-08-22)
 
-
 ### Bug Fixes
 
-* carousel and icon prefab ([2a55666](https://github.com/bettyblocks/material-ui-component-set/commit/2a55666ea0e8825254e04f5c90ee3f408d040ed0))
-* remove style check on text component ([53a76f6](https://github.com/bettyblocks/material-ui-component-set/commit/53a76f6da41c628b8a418531f017d9dd03724300))
-* small changes ([2fb81ee](https://github.com/bettyblocks/material-ui-component-set/commit/2fb81ee9d950a16c3face9802dfd8c601f090d06))
-
+- carousel and icon prefab ([2a55666](https://github.com/bettyblocks/material-ui-component-set/commit/2a55666ea0e8825254e04f5c90ee3f408d040ed0))
+- remove style check on text component ([53a76f6](https://github.com/bettyblocks/material-ui-component-set/commit/53a76f6da41c628b8a418531f017d9dd03724300))
+- small changes ([2fb81ee](https://github.com/bettyblocks/material-ui-component-set/commit/2fb81ee9d950a16c3face9802dfd8c601f090d06))
 
 ### Features
 
-* add new options to text ([eca41a3](https://github.com/bettyblocks/material-ui-component-set/commit/eca41a32012eeafc9279acb66111635a5fb42275))
-* add option carousel ([ea3d009](https://github.com/bettyblocks/material-ui-component-set/commit/ea3d0093047f8a6a82d1565aeb6f0a8eb7701229))
-* add option to avatar/carousel/carouselimage/ ([9753359](https://github.com/bettyblocks/material-ui-component-set/commit/97533596b56c57dd1929de2fe374fb9f3c366312))
-* add options to alert ([f4ba13d](https://github.com/bettyblocks/material-ui-component-set/commit/f4ba13d9108c0d2339b2921f9d1b82360dfc0753))
-* add options to chip component ([075c3e2](https://github.com/bettyblocks/material-ui-component-set/commit/075c3e2ee2498b450f7e534ec6e149c9178896c1))
-* add options to divider and snackbar ([266c18f](https://github.com/bettyblocks/material-ui-component-set/commit/266c18ff1b13e8b5ba6e02f5c5b080fc43606876))
-* add options to icon ([5573eff](https://github.com/bettyblocks/material-ui-component-set/commit/5573eff849e2a4979d6444ee1899672589540c82))
-* add options to media component ([f957c81](https://github.com/bettyblocks/material-ui-component-set/commit/f957c81c86c009bff1c7f11b8a68411aa4f3aa57))
-* add options to progress ([722ad56](https://github.com/bettyblocks/material-ui-component-set/commit/722ad56e1319459426dea3227515659367666cba))
-* add options to text prefab ([0421210](https://github.com/bettyblocks/material-ui-component-set/commit/04212106c0f4eb0f5aa00a93fa1e2b67fb65fb74))
+- add new options to text ([eca41a3](https://github.com/bettyblocks/material-ui-component-set/commit/eca41a32012eeafc9279acb66111635a5fb42275))
+- add option carousel ([ea3d009](https://github.com/bettyblocks/material-ui-component-set/commit/ea3d0093047f8a6a82d1565aeb6f0a8eb7701229))
+- add option to avatar/carousel/carouselimage/ ([9753359](https://github.com/bettyblocks/material-ui-component-set/commit/97533596b56c57dd1929de2fe374fb9f3c366312))
+- add options to alert ([f4ba13d](https://github.com/bettyblocks/material-ui-component-set/commit/f4ba13d9108c0d2339b2921f9d1b82360dfc0753))
+- add options to chip component ([075c3e2](https://github.com/bettyblocks/material-ui-component-set/commit/075c3e2ee2498b450f7e534ec6e149c9178896c1))
+- add options to divider and snackbar ([266c18f](https://github.com/bettyblocks/material-ui-component-set/commit/266c18ff1b13e8b5ba6e02f5c5b080fc43606876))
+- add options to icon ([5573eff](https://github.com/bettyblocks/material-ui-component-set/commit/5573eff849e2a4979d6444ee1899672589540c82))
+- add options to media component ([f957c81](https://github.com/bettyblocks/material-ui-component-set/commit/f957c81c86c009bff1c7f11b8a68411aa4f3aa57))
+- add options to progress ([722ad56](https://github.com/bettyblocks/material-ui-component-set/commit/722ad56e1319459426dea3227515659367666cba))
+- add options to text prefab ([0421210](https://github.com/bettyblocks/material-ui-component-set/commit/04212106c0f4eb0f5aa00a93fa1e2b67fb65fb74))
 
 # [2.27.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.26.0...v2.27.0) (2022-08-17)
 
-
 ### Features
 
-* replaced setOption in column layout TMPLT-1653 ([14e3403](https://github.com/bettyblocks/material-ui-component-set/commit/14e3403395523a6676c5a230f68274a7f06a137c))
+- replaced setOption in column layout TMPLT-1653 ([14e3403](https://github.com/bettyblocks/material-ui-component-set/commit/14e3403395523a6676c5a230f68274a7f06a137c))
 
 # [2.26.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.25.0...v2.26.0) (2022-08-12)
 
-
 ### Features
 
-* implement new cloneStructure and setOption ([1dc4a0a](https://github.com/bettyblocks/material-ui-component-set/commit/1dc4a0a0bc546406e55e01aac4306ba9be70d0e6))
+- implement new cloneStructure and setOption ([1dc4a0a](https://github.com/bettyblocks/material-ui-component-set/commit/1dc4a0a0bc546406e55e01aac4306ba9be70d0e6))
 
 # [2.25.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.24.0...v2.25.0) (2022-08-11)
 
-
 ### Features
 
-* add reconfigure ([c73810a](https://github.com/bettyblocks/material-ui-component-set/commit/c73810a8ed58fca911197a97df5c8c47fc0892eb))
+- add reconfigure ([c73810a](https://github.com/bettyblocks/material-ui-component-set/commit/c73810a8ed58fca911197a97df5c8c47fc0892eb))
 
 # [2.24.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.23.0...v2.24.0) (2022-08-11)
 
-
 ### Bug Fixes
 
-* added missing parameters in login interaction ([83a6e93](https://github.com/bettyblocks/material-ui-component-set/commit/83a6e93efdeca9565d0021878314382e17269835))
-* implement makeBettyInput in loginForm ([e7a9a12](https://github.com/bettyblocks/material-ui-component-set/commit/e7a9a1206ea3d964f10258842e25a1c70811bddb))
-* lint errors ([5fc849d](https://github.com/bettyblocks/material-ui-component-set/commit/5fc849df7a7e7adb93ef4cbcbf803f7a0f1f9935))
-* lint errors ([af0b431](https://github.com/bettyblocks/material-ui-component-set/commit/af0b4317538e7d86cd9f786252c29410f9b1e070))
-* other way of creating forms ([1d68611](https://github.com/bettyblocks/material-ui-component-set/commit/1d686111fb6ea51c410a7df85f36bf291047ec8e))
-* remove unused imports ([83b2dc0](https://github.com/bettyblocks/material-ui-component-set/commit/83b2dc0185233cb2eda2d1d8e258d5d4c835f337))
-* use model instead of modelid to fill in model ([def7a55](https://github.com/bettyblocks/material-ui-component-set/commit/def7a55358b6cd24f17fcd97c9ab6a3c54247988))
-* use structure in actionJS form ([365f6e6](https://github.com/bettyblocks/material-ui-component-set/commit/365f6e6e458c07e201226b8b18224246f13d1db5))
-* use update helper in the update form ([bcf7538](https://github.com/bettyblocks/material-ui-component-set/commit/bcf75389881591e31174301de256bba37b9f8e30))
-
+- added missing parameters in login interaction ([83a6e93](https://github.com/bettyblocks/material-ui-component-set/commit/83a6e93efdeca9565d0021878314382e17269835))
+- implement makeBettyInput in loginForm ([e7a9a12](https://github.com/bettyblocks/material-ui-component-set/commit/e7a9a1206ea3d964f10258842e25a1c70811bddb))
+- lint errors ([5fc849d](https://github.com/bettyblocks/material-ui-component-set/commit/5fc849df7a7e7adb93ef4cbcbf803f7a0f1f9935))
+- lint errors ([af0b431](https://github.com/bettyblocks/material-ui-component-set/commit/af0b4317538e7d86cd9f786252c29410f9b1e070))
+- other way of creating forms ([1d68611](https://github.com/bettyblocks/material-ui-component-set/commit/1d686111fb6ea51c410a7df85f36bf291047ec8e))
+- remove unused imports ([83b2dc0](https://github.com/bettyblocks/material-ui-component-set/commit/83b2dc0185233cb2eda2d1d8e258d5d4c835f337))
+- use model instead of modelid to fill in model ([def7a55](https://github.com/bettyblocks/material-ui-component-set/commit/def7a55358b6cd24f17fcd97c9ab6a3c54247988))
+- use structure in actionJS form ([365f6e6](https://github.com/bettyblocks/material-ui-component-set/commit/365f6e6e458c07e201226b8b18224246f13d1db5))
+- use update helper in the update form ([bcf7538](https://github.com/bettyblocks/material-ui-component-set/commit/bcf75389881591e31174301de256bba37b9f8e30))
 
 ### Features
 
-* add create beta form prefab and use generic success alert message ([40ae731](https://github.com/bettyblocks/material-ui-component-set/commit/40ae7314432c1503ec03191409d459525ed820d7))
-* added login form using pro coder api ([54ace84](https://github.com/bettyblocks/material-ui-component-set/commit/54ace8479a5cd898604d351962a3902ed18786b3))
+- add create beta form prefab and use generic success alert message ([40ae731](https://github.com/bettyblocks/material-ui-component-set/commit/40ae7314432c1503ec03191409d459525ed820d7))
+- added login form using pro coder api ([54ace84](https://github.com/bettyblocks/material-ui-component-set/commit/54ace8479a5cd898604d351962a3902ed18786b3))
 
 # [2.23.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.22.0...v2.23.0) (2022-08-11)
 
-
 ### Features
 
-* add option categories to data components TMPLT-1632 ([60db294](https://github.com/bettyblocks/material-ui-component-set/commit/60db294e48f586eb19bae8198495db55b6702d69))
+- add option categories to data components TMPLT-1632 ([60db294](https://github.com/bettyblocks/material-ui-component-set/commit/60db294e48f586eb19bae8198495db55b6702d69))
 
 # [2.22.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.21.1...v2.22.0) (2022-08-11)
 
-
 ### Bug Fixes
 
-* bump cli version ([7d1dec6](https://github.com/bettyblocks/material-ui-component-set/commit/7d1dec66f4949b17551636cc64bb65a4895c33c3))
-
+- bump cli version ([7d1dec6](https://github.com/bettyblocks/material-ui-component-set/commit/7d1dec66f4949b17551636cc64bb65a4895c33c3))
 
 ### Features
 
-* add optioncategories and changed names of const options ([8bd76e4](https://github.com/bettyblocks/material-ui-component-set/commit/8bd76e4a982779c1d51f73a0a2eff829a6aa8ddc))
+- add optioncategories and changed names of const options ([8bd76e4](https://github.com/bettyblocks/material-ui-component-set/commit/8bd76e4a982779c1d51f73a0a2eff829a6aa8ddc))
 
 ## [2.21.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.21.0...v2.21.1) (2022-08-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# [2.56.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.56.0) (2022-09-22)
+
+
+### Bug Fixes
+
+* decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
+* fix the datalist ([bcc6f01](https://github.com/bettyblocks/material-ui-component-set/commit/bcc6f01a3452e4073875036f16c96b4daa4ea90d))
+* remove unused var ([ff41513](https://github.com/bettyblocks/material-ui-component-set/commit/ff41513c06f8208222a35e285d19e13c07b6ef2e))
+* trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
+
+
+### Features
+
+* add checkbox tsx page ([3220ce8](https://github.com/bettyblocks/material-ui-component-set/commit/3220ce852d50750615b3816318ad49025fd18015))
+* add checklist template ([7342aa3](https://github.com/bettyblocks/material-ui-component-set/commit/7342aa37953e31166a4511242e6e029b9fc7a509))
+* add checklist template ([166da2f](https://github.com/bettyblocks/material-ui-component-set/commit/166da2f3bef81b60d386d597df2eeba6ef8428a7))
+* add datalist ([cb3a9b3](https://github.com/bettyblocks/material-ui-component-set/commit/cb3a9b39ad858ca2d4951b09b7c7dbb2be40fc30))
+
 ## [2.55.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.55.3) (2022-09-22)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.55.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.55.3) (2022-09-22)
+
+
+### Bug Fixes
+
+* decimal input value not set correctly ([6afcafa](https://github.com/bettyblocks/material-ui-component-set/commit/6afcafaf28f3cc64790f82844784dde1ce5a28f6))
+* trigger pipelines ([f50b6f3](https://github.com/bettyblocks/material-ui-component-set/commit/f50b6f37707932ff49e175bef82156a42623c253))
+
 ## [2.55.2](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.1...v2.55.2) (2022-09-20)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# [2.57.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.56.0...v2.57.0) (2022-09-23)
+
+
+### Bug Fixes
+
+* add related model ids to belongs_to ([878a462](https://github.com/bettyblocks/material-ui-component-set/commit/878a4620b6d7f9cfcd1facce8d224bd689011c59))
+* bug when no orderby is cleared ([e73af0f](https://github.com/bettyblocks/material-ui-component-set/commit/e73af0f630f64a8bc5762e877308dcba7f2404f4))
+* change variable model conditions ([e255129](https://github.com/bettyblocks/material-ui-component-set/commit/e255129be11b0e7ab33ce380d7b5e59cf1e275b4))
+* error message typo ([916e9c4](https://github.com/bettyblocks/material-ui-component-set/commit/916e9c47f72cd023ae2725da80c9a9a38b2e5612))
+* remove unused helpers ([f3b9fea](https://github.com/bettyblocks/material-ui-component-set/commit/f3b9fea1a631cf3ce606642fade27627d8d8e81a))
+* use id for non property select ([0a38376](https://github.com/bettyblocks/material-ui-component-set/commit/0a38376ad75a0fe3daf10fb35906468a1399bb34))
+* use model instead of modelcontext ([9886a78](https://github.com/bettyblocks/material-ui-component-set/commit/9886a78d06bbe13aca551236a267742a934a2de4))
+
+
+### Features
+
+* able to drag multi autocomplete outside form ([8d268ec](https://github.com/bettyblocks/material-ui-component-set/commit/8d268ec44e8bf186c98446f5ddb918e617815ef9))
+* add default label to multi autocomplete ([edce4ed](https://github.com/bettyblocks/material-ui-component-set/commit/edce4ed4ea386c224f84a5496e94599c5b53ea87))
+* add relatedModelIds to create / update form ([a58814e](https://github.com/bettyblocks/material-ui-component-set/commit/a58814e2a97a04db013c023918c050a8e9f5b2e2))
+* drag an autocomplete outside a form ([932f61d](https://github.com/bettyblocks/material-ui-component-set/commit/932f61dacae82139f10d2d1ac753a6f551e07de3))
+* drag radio buttons outside form ([d2c9a03](https://github.com/bettyblocks/material-ui-component-set/commit/d2c9a0340129c5216487566fd3a019cd53332d04))
+* only show model based options if necessary ([f1a46f3](https://github.com/bettyblocks/material-ui-component-set/commit/f1a46f3cd882a35085278e9d9462bd9a3c1b7ee7))
+* use id as default label ([77657e7](https://github.com/bettyblocks/material-ui-component-set/commit/77657e73495786535f6c645e9c6bde507ba01380))
+
 # [2.56.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.55.2...v2.56.0) (2022-09-22)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.55.2",
+  "version": "2.55.3",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.56.0",
+  "version": "2.57.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.55.3",
+  "version": "2.56.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -23,7 +23,6 @@
       actionProperty,
       actionVariableId: name,
       closeOnSelect,
-      required: defaultRequired,
       dataComponentAttribute: dataComponentAttributeRaw,
       disabled: initialDisabled,
       errorType,
@@ -34,24 +33,26 @@
       label: labelRaw,
       labelProperty: labelPropertyId = '',
       margin,
+      maxlength,
+      minlength,
+      minvalue,
+      model,
       nameAttribute: nameAttributeRaw,
       order,
       orderBy,
+      pattern,
       placeholder: placeholderRaw,
+      required: defaultRequired,
       size,
-      value: valueRaw,
+      type,
       validationBelowMinimum = [''],
       validationPatternMismatch = [''],
       validationTooLong = [''],
       validationTooShort = [''],
       validationTypeMismatch = [''],
       validationValueMissing = [''],
+      value: valueRaw,
       variant,
-      maxlength,
-      minlength,
-      pattern,
-      minvalue,
-      type,
     } = options;
     const numberPropTypes = ['serial', 'minutes', 'count', 'integer'];
 
@@ -96,16 +97,19 @@
     const tooShortMessage = useText(validationTooShort);
     const belowMinimumMessage = useText(validationBelowMinimum);
     const helperTextResolved = useText(helperTextRaw);
-
-    const modelProperty = getProperty(actionProperty.modelProperty) || {};
+    const modelProperty = getProperty(actionProperty.modelProperty || '') || {};
     const labelProperty = getProperty(labelPropertyId) || {};
 
     const { modelId: propertyModelId } = modelProperty;
-
-    const modelId = modelProperty.referenceModelId || propertyModelId;
-
-    const model = getModel(modelId);
-    const defaultLabelProperty = getProperty(model.labelPropertyId || '') || {};
+    const modelId =
+      modelProperty.referenceModelId || propertyModelId || model || '';
+    const propertyModel = getModel(modelId);
+    const defaultLabelProperty =
+      getProperty(
+        propertyModel && propertyModel.labelPropertyId
+          ? propertyModel.labelPropertyId
+          : '',
+      ) || {};
     const idProperty = getIdProperty(modelId) || {};
     const isListProperty =
       modelProperty.kind === 'LIST' || modelProperty.kind === 'list';
@@ -223,20 +227,20 @@
     let message = '';
 
     if (!isListProperty && !isDev) {
-      if (!modelId) {
-        message = 'No model selected';
-        valid = false;
-      }
       if (!hasSearch && !hasValue) {
         message = 'No property selected';
         valid = false;
       }
       if (!hasValue) {
-        message = 'No value propery selected';
+        message = 'No value property selected';
         valid = false;
       }
       if (!hasSearch) {
         message = 'No label property selected';
+        valid = false;
+      }
+      if (!modelId) {
+        message = 'No model selected';
         valid = false;
       }
     }

--- a/src/components/multiAutoCompleteInput.js
+++ b/src/components/multiAutoCompleteInput.js
@@ -32,35 +32,35 @@
       dataComponentAttribute: dataComponentAttributeRaw,
       disabled,
       errorType,
-      label: labelRaw,
-      labelProperty: labelPropertyId = '',
       filter: filterRaw,
       fullWidth,
       helperText: helperTextRaw,
       hideLabel,
+      label: labelRaw,
+      labelProperty: labelPropertyId = '',
       margin,
-      model: modelId,
-      required,
+      maxlength,
+      minlength,
+      minvalue,
+      model,
       nameAttribute: nameAttributeRaw,
       optionType,
       order,
       orderBy,
+      pattern,
       placeholder: placeholderRaw,
       renderCheckboxes,
+      required,
       showError,
       size,
-      variant,
+      type,
       validationBelowMinimum = [''],
       validationPatternMismatch = [''],
       validationTooLong = [''],
       validationTooShort = [''],
       validationTypeMismatch = [''],
       validationValueMissing = [''],
-      maxlength,
-      minlength,
-      pattern,
-      minvalue,
-      type,
+      variant,
     } = options;
     const numberPropTypes = ['serial', 'minutes', 'count', 'integer'];
     /*
@@ -100,12 +100,19 @@
     const belowMinimumMessage = useText(validationBelowMinimum);
     const helperTextResolved = useText(helperTextRaw);
 
-    const modelProperty = getProperty(actionProperty.modelProperty) || {};
+    const modelProperty = getProperty(actionProperty.modelProperty || '') || {};
 
     const labelProperty = getProperty(labelPropertyId) || {};
-
-    const model = getModel(modelId);
-    const defaultLabelProperty = getProperty(model.labelPropertyId || '') || {};
+    const { modelId: propertyModelId } = modelProperty;
+    const modelId =
+      modelProperty.referenceModelId || propertyModelId || model || '';
+    const propertyModel = getModel(modelId);
+    const defaultLabelProperty =
+      getProperty(
+        propertyModel && propertyModel.labelPropertyId
+          ? propertyModel.labelPropertyId
+          : '',
+      ) || {};
     const idProperty = getIdProperty(modelId || '') || {};
 
     const isListProperty =
@@ -227,7 +234,7 @@
     const hasSearch = searchProp && searchProp.id;
     const hasValue = !!(valueProp && valueProp.id);
 
-    let valid = false;
+    let valid = true;
     let message = '';
 
     /*
@@ -257,64 +264,50 @@
     /*
      * We do some validations that checks if all required options are set. We do this in one place to prevent clutter further on
      */
-    switch (optionType) {
-      case 'model': {
-        if (!model) {
-          message = 'No model selected';
-          break;
-        }
-        if (!hasSearch && !hasValue) {
-          message = 'No property selected';
-          break;
-        }
-        if (!hasValue) {
-          message = 'No value property selected';
-          break;
-        }
-        if (!hasSearch) {
-          message = 'No label property selected';
-          break;
-        }
-
-        valid = true;
-        break;
+    if (!isListProperty && !isDev) {
+      if (!hasSearch && !hasValue) {
+        message = 'No property selected';
+        valid = false;
       }
-      case 'property': {
-        if (!isListProperty) {
-          message = 'No property of type "List" selected';
-          break;
-        }
-
-        valid = true;
-        break;
+      if (!hasValue) {
+        message = 'No value property selected';
+        valid = false;
       }
-      default: {
-        message = 'Invalid value for optionType option';
-        break;
+      if (!hasSearch) {
+        message = 'No label property selected';
+        valid = false;
+      }
+      if (!modelId) {
+        message = 'No model selected';
+        valid = false;
       }
     }
 
-    const parentIdProperty = getIdProperty(modelProperty.modelId).id;
+    const parentProperty = getIdProperty(modelId);
+    const parentIdProperty = parentProperty ? parentProperty.id : '';
     const parentIdValue = B.useProperty(parentIdProperty);
     const queryWasResolvable = !!parentIdValue;
 
+    let valuesFilter = {};
+    let valueFilter;
     // this should be merged into the final filter
-    const valuesFilter = {
-      _and: [
-        {
-          [modelProperty.inverseAssociationId]: {
-            [parentIdProperty]: {
-              eq: {
-                id: [parentIdProperty],
-                type: 'PROPERTY',
+    if (modelProperty.id) {
+      valuesFilter = {
+        _and: [
+          {
+            [modelProperty.inverseAssociationId]: {
+              [parentIdProperty]: {
+                eq: {
+                  id: [parentIdProperty],
+                  type: 'PROPERTY',
+                },
               },
             },
           },
-        },
-      ],
-    };
-
-    const valueFilter = useFilter(valuesFilter);
+        ],
+      };
+      valueFilter = useFilter(valuesFilter);
+    }
 
     useAllQuery(
       modelId,
@@ -340,7 +333,7 @@
     useEffect(() => {
       let debounceInput;
 
-      if (optionType === 'model') {
+      if (optionType === 'model' || optionType === 'variable') {
         if (inputValue !== debouncedInputValue) {
           debounceInput = setTimeout(() => {
             setDebouncedInputValue(inputValue);
@@ -349,7 +342,7 @@
       }
 
       return () => {
-        if (optionType === 'model') {
+        if (optionType === 'model' || optionType === 'variable') {
           clearTimeout(debounceInput);
         }
       };
@@ -594,7 +587,7 @@
         return modelProperty.values.map((propertyValue) => propertyValue.value);
       }
 
-      if (optionType === 'model') {
+      if (optionType === 'model' || optionType === 'variable') {
         if (!results) {
           return [];
         }
@@ -687,7 +680,7 @@
         <Autocomplete
           disableCloseOnSelect={!closeOnSelect}
           disabled={disabled}
-          {...(optionType === 'model' && {
+          {...((optionType === 'model' || optionType === 'variable') && {
             getOptionLabel: renderLabel,
           })}
           inputValue={inputValue}
@@ -698,7 +691,7 @@
 
             let triggerEventValue;
 
-            if (optionType === 'model') {
+            if (optionType === 'model' || optionType === 'variable') {
               setDebouncedInputValue('');
               triggerEventValue =
                 newValue.length === 0
@@ -742,7 +735,7 @@
           options={currentOptions}
           renderInput={(params) => (
             <>
-              {optionType === 'model' && (
+              {(optionType === 'model' || optionType === 'variable') && (
                 <input
                   type="hidden"
                   key={value[valueProp.name] ? 'hasValue' : 'isEmpty'}

--- a/src/components/radioinput.js
+++ b/src/components/radioinput.js
@@ -5,46 +5,174 @@
   orientation: 'HORIZONTAL',
   jsx: (() => {
     const {
-      actionVariableId: name,
       actionProperty,
-      propertyData,
-      disabled,
+      actionVariableId: name,
+      dataComponentAttribute = ['Radio'],
+      disabled: initialIsDisabled,
+      filter,
+      fullWidth,
+      helperText = [''],
+      hideLabel,
+      label,
       labelPosition,
+      labelProperty,
+      margin,
+      model,
+      order,
+      orderBy,
+      required,
       row,
       size,
-      fullWidth,
-      margin,
-      helperText = [''],
-      label,
-      required,
-      hideLabel,
       validationValueMissing = [''],
       value: prefabValue,
-      dataComponentAttribute = ['Select'],
     } = options;
-    const { env, getProperty, useText } = B;
+    const { env, getProperty, useText, useAllQuery } = B;
     const {
       FormControl: MUIFormControl,
-      RadioGroup,
       FormControlLabel: MUIFormControlLabel,
       FormHelperText,
       FormLabel,
       Radio,
+      RadioGroup,
     } = window.MaterialUI.Core;
     const isDev = env === 'dev';
+    const modelProperty = getProperty(actionProperty.modelProperty || '') || {};
+
     const [errorState, setErrorState] = useState(false);
     const [afterFirstInvalidation, setAfterFirstInvalidation] = useState(false);
     const [helper, setHelper] = useState(useText(helperText));
+    const [interactionFilter, setInteractionFilter] = useState({});
+    const [disabled, setIsDisabled] = useState(initialIsDisabled);
     const mounted = useRef(false);
-    const { values = [] } = getProperty(actionProperty.modelProperty) || {};
-    const [currentValue, setCurrentValue] = useState(useText(prefabValue));
+    const getValue = (val) => (isNaN(Number(val)) ? val : Number(val));
     const labelText = useText(label);
     const defaultValueText = useText(prefabValue);
     const helperTextResolved = useText(helperText);
     const validationMessageText = useText(validationValueMissing);
     const dataComponentAttributeValue = useText(dataComponentAttribute);
-    const { kind, values: listValues } = getProperty(propertyData) || {};
-    let radioValues = [];
+
+    const {
+      referenceModelId,
+      modelId = model,
+      kind,
+      values = [],
+    } = modelProperty;
+
+    const isListProperty = kind === 'list' || kind === 'LIST';
+    const [currentValue, setCurrentValue] = useState(
+      isListProperty ? useText(prefabValue) : getValue(prefabValue),
+    );
+
+    B.defineFunction('Clear', () => setCurrentValue(''));
+    B.defineFunction('Enable', () => setIsDisabled(false));
+    B.defineFunction('Disable', () => setIsDisabled(true));
+
+    const transformValue = (arg) => {
+      if (arg instanceof Date) {
+        return arg.toISOString();
+      }
+
+      return arg;
+    };
+
+    const deepMerge = (...objects) => {
+      const isObject = (item) =>
+        item && typeof item === 'object' && !Array.isArray(item);
+
+      return objects.reduce((accumulator, object) => {
+        Object.keys(object).forEach((key) => {
+          const accumulatorValue = accumulator[key];
+          const valueArg = object[key];
+
+          if (Array.isArray(accumulatorValue) && Array.isArray(valueArg)) {
+            accumulator[key] = accumulatorValue.concat(valueArg);
+          } else if (isObject(accumulatorValue) && isObject(valueArg)) {
+            accumulator[key] = deepMerge(accumulatorValue, valueArg);
+          } else {
+            accumulator[key] = valueArg;
+          }
+        });
+        return accumulator;
+      }, {});
+    };
+
+    const orderByArray = [orderBy].flat();
+    const sort =
+      !isDev && orderBy.id
+        ? orderByArray.reduceRight((acc, orderByProperty, index) => {
+            const prop = getProperty(orderByProperty);
+            return index === orderByArray.length - 1
+              ? { [prop.name]: order.toUpperCase() }
+              : { [prop.name]: acc };
+          }, {})
+        : {};
+
+    let interactionFilters = {};
+
+    const isEmptyValue = (arg) =>
+      !arg || (Array.isArray(arg) && arg.length === 0);
+
+    const clauses = Object.entries(interactionFilter)
+      .filter(([, { value: valueArg }]) => !isEmptyValue(valueArg))
+      .map(([, { property: propertyArg, value: valueArg }]) =>
+        propertyArg.id.reduceRight((acc, field, index, arr) => {
+          const isLast = index === arr.length - 1;
+          if (isLast) {
+            return Array.isArray(valueArg)
+              ? {
+                  _or: valueArg.map((el) => ({
+                    [field]: { [propertyArg.operator]: el },
+                  })),
+                }
+              : { [field]: { [propertyArg.operator]: valueArg } };
+          }
+
+          return { [field]: acc };
+        }, {}),
+      );
+
+    interactionFilters =
+      clauses.length > 1 ? { _and: clauses } : clauses[0] || {};
+
+    const completeFilter = deepMerge(filter, interactionFilters);
+
+    const { data, loading, refetch } = useAllQuery(
+      referenceModelId || modelId,
+      {
+        filter: completeFilter,
+        take: 50,
+        variables: {
+          ...(orderBy.id ? { sort: { relation: sort } } : {}),
+        },
+      },
+      !model,
+    );
+
+    useEffect(() => {
+      B.defineFunction('Refetch', () => refetch());
+
+      /**
+       * @name Filter
+       * @param {Property} property
+       * @returns {Void}
+       */
+      B.defineFunction(
+        'Filter',
+        ({ event, property: propertyArg, interactionId }) => {
+          setInteractionFilter((s) => ({
+            ...s,
+            [interactionId]: {
+              property: propertyArg,
+              value: event.target ? event.target.value : transformValue(event),
+            },
+          }));
+        },
+      );
+
+      B.defineFunction('ResetFilter', () => {
+        setInteractionFilter({});
+      });
+    }, []);
 
     useEffect(() => {
       B.defineFunction('Reset', () => setCurrentValue(defaultValueText));
@@ -79,7 +207,7 @@
         handleValidation();
       }
 
-      setCurrentValue(eventValue);
+      setCurrentValue(isListProperty ? eventValue : getValue(eventValue));
     };
 
     const validationHandler = () => {
@@ -94,6 +222,16 @@
       }
     }, [isDev, defaultValueText]);
 
+    let valid = true;
+    let message = '';
+
+    if (!isListProperty && !isDev) {
+      if (!modelId) {
+        message = 'No model selected';
+        valid = false;
+      }
+    }
+
     // renders the radio component
     const renderRadio = (optionValue, optionLabel) => (
       <MUIFormControlLabel
@@ -106,11 +244,38 @@
     );
 
     const renderRadios = () => {
-      if (isDev && kind === 'LIST') {
-        return listValues.map((item) => renderRadio(item.value, item.value));
+      if (!valid) {
+        return <span>{message}</span>;
       }
-      radioValues = values.map((item) => item);
-      return values.map((item) => renderRadio(item.value, item.value));
+
+      if (isDev && !isListProperty) return renderRadio('value', 'Placeholder');
+
+      if (isListProperty) {
+        return values.map(({ value }) => renderRadio(value, value));
+      }
+
+      if (!loading && !isDev) {
+        let labelKey = 'id';
+        if (labelProperty) {
+          labelKey = B.getProperty(labelProperty).name;
+        } else {
+          const modelReference = B.getModel(referenceModelId || modelId);
+          if (modelReference.labelPropertyId)
+            labelKey = B.getProperty(modelReference.labelPropertyId).name;
+        }
+
+        const results = data ? data.results : [];
+
+        return results.map((result) => {
+          return renderRadio(result.id, result[labelKey]);
+        });
+      }
+
+      if (!loading && !data) {
+        return <span>unable to fetch data</span>;
+      }
+
+      return <span>loading...</span>;
     };
 
     const RadioComp = (
@@ -141,7 +306,7 @@
           type="text"
           tabIndex="-1"
           required={required}
-          value={radioValues.includes(currentValue) ? currentValue : ''}
+          value={currentValue}
         />
       </MUIFormControl>
     );

--- a/src/components/textField.js
+++ b/src/components/textField.js
@@ -261,10 +261,10 @@
     const decimalHandler = (val) => {
       if (!isDev) {
         if (separator === 'comma') {
-          return val.replaceAll('.', '').replace(/[^0-9.|,]/g, '');
+          return val.replaceAll('.', ',').replace(/[^0-9.|,]/g, '');
         }
         if (separator === 'dot') {
-          return val.replaceAll(',', '').replace(/[^0-9.|,]/g, '');
+          return val.replace(/[^0-9.|,]/g, '');
         }
       }
 

--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -3451,9 +3451,7 @@ const beforeCreate = ({
   const [stepNumber, setStepNumber] = React.useState(1);
   const [headerPartialId, setHeaderPartialId] = React.useState('');
   const [footerPartialId, setFooterPartialId] = React.useState('');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('private');
+  const permissions: PermissionType = 'inherit';
   const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const createFormId = createUuid();
@@ -4009,7 +4007,6 @@ const beforeCreate = ({
         if (!createForm) throw new Error('No create form found');
         createForm.id = createFormId;
 
-        setPermissions('private');
         const result = await prepareAction(
           createFormId,
           idProperty,

--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -71,6 +71,7 @@ import {
 } from './structures';
 import { options as defaults } from './structures/ActionJSForm/options';
 import { Properties, IdPropertyProps, ModelProps, ModelQuery } from './types';
+import { PermissionType } from './types/types';
 
 const interactions: PrefabInteraction[] = [
   {
@@ -3428,6 +3429,7 @@ const beforeCreate = ({
   const {
     useModelQuery,
     prepareAction,
+    getPageAuthenticationProfileId,
     cloneStructure,
     setOption,
     createUuid,
@@ -3449,6 +3451,10 @@ const beforeCreate = ({
   const [stepNumber, setStepNumber] = React.useState(1);
   const [headerPartialId, setHeaderPartialId] = React.useState('');
   const [footerPartialId, setFooterPartialId] = React.useState('');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('private');
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const createFormId = createUuid();
   const editFormId = createUuid();
@@ -4003,11 +4009,16 @@ const beforeCreate = ({
         if (!createForm) throw new Error('No create form found');
         createForm.id = createFormId;
 
+        setPermissions('private');
         const result = await prepareAction(
           createFormId,
           idProperty,
           filteredproperties,
           'create',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
 
         Object.values(result.variables).forEach(
@@ -4230,6 +4241,10 @@ const beforeCreate = ({
           idProperty,
           filteredproperties,
           'update',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
         setOption(editForm, 'actionId', (opts: PrefabComponentOption) => ({
           ...opts,
@@ -4455,6 +4470,10 @@ const beforeCreate = ({
           idProperty,
           undefined,
           'delete',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
         setOption(deleteForm, 'actionId', (opts: PrefabComponentOption) => ({
           ...opts,

--- a/src/prefabs/createForm.tsx
+++ b/src/prefabs/createForm.tsx
@@ -38,6 +38,7 @@ const beforeCreate = ({
   const [model, setModel] = React.useState(null);
   const [idProperty, setIdProperty] = React.useState(null);
   const [properties, setProperties] = React.useState([]);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('private');
 
   const [validationMessage, setValidationMessage] = React.useState('');

--- a/src/prefabs/createForm.tsx
+++ b/src/prefabs/createForm.tsx
@@ -6,6 +6,7 @@ import {
   PrefabInteraction,
 } from '@betty-blocks/component-sdk';
 import { Form } from './structures/ActionJSForm';
+import { PermissionType } from './types/types';
 
 const beforeCreate = ({
   close,
@@ -38,8 +39,7 @@ const beforeCreate = ({
   const [model, setModel] = React.useState(null);
   const [idProperty, setIdProperty] = React.useState(null);
   const [properties, setProperties] = React.useState([]);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('private');
+  const permissions: PermissionType = 'inherit';
 
   const [validationMessage, setValidationMessage] = React.useState('');
   const componentId = createUuid();

--- a/src/prefabs/createForm.tsx
+++ b/src/prefabs/createForm.tsx
@@ -117,6 +117,7 @@ const beforeCreate = ({
                     property,
                     variable,
                     result.relatedIdProperties,
+                    result.relatedModelIds,
                   ),
                 );
                 break;

--- a/src/prefabs/createForm.tsx
+++ b/src/prefabs/createForm.tsx
@@ -29,6 +29,7 @@ const beforeCreate = ({
     createUuid,
     makeBettyInput,
     prepareAction,
+    getPageAuthenticationProfileId,
     setOption,
     useModelQuery,
   } = helpers;
@@ -37,9 +38,12 @@ const beforeCreate = ({
   const [model, setModel] = React.useState(null);
   const [idProperty, setIdProperty] = React.useState(null);
   const [properties, setProperties] = React.useState([]);
+  const [permissions, setPermissions] = React.useState('private');
 
   const [validationMessage, setValidationMessage] = React.useState('');
   const componentId = createUuid();
+
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const modelRequest = useModelQuery({
     variables: { id: modelId },
@@ -102,6 +106,10 @@ const beforeCreate = ({
             idProperty,
             properties,
             'create',
+            undefined,
+            undefined,
+            permissions,
+            pageAuthenticationProfileId,
           );
           const structure = originalPrefab.structure[0];
 

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -70,6 +70,7 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState([]);
   const [modelBased, setmodelBased] = React.useState(true);
   const [actionName, setActionName] = React.useState('');
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('private');
   const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -35,6 +35,7 @@ const beforeCreate = ({
     createUuid,
     makeBettyInput,
     prepareAction,
+    getPageAuthenticationProfileId,
     setOption,
     useModelQuery,
   } = helpers;
@@ -69,6 +70,8 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState([]);
   const [modelBased, setmodelBased] = React.useState(true);
   const [actionName, setActionName] = React.useState('');
+  const [permissions, setPermissions] = React.useState('private');
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const [validationMessage, setValidationMessage] = React.useState('');
   const componentId = createUuid();
@@ -202,6 +205,8 @@ const beforeCreate = ({
             modelBased ? 'empty' : 'custom',
             null,
             actionName,
+            permissions,
+            pageAuthenticationProfileId,
           );
 
           const structure = originalPrefab.structure[0];

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -6,6 +6,7 @@ import {
   PrefabInteraction,
 } from '@betty-blocks/component-sdk';
 import { Form } from './structures/ActionJSForm';
+import { PermissionType } from './types/types';
 
 const beforeCreate = ({
   close,
@@ -71,7 +72,8 @@ const beforeCreate = ({
   const [modelBased, setmodelBased] = React.useState(true);
   const [actionName, setActionName] = React.useState('');
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('private');
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('private');
   const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const [validationMessage, setValidationMessage] = React.useState('');

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -71,9 +71,7 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState([]);
   const [modelBased, setmodelBased] = React.useState(true);
   const [actionName, setActionName] = React.useState('');
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('private');
+  const permissions: PermissionType = 'inherit';
   const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const [validationMessage, setValidationMessage] = React.useState('');

--- a/src/prefabs/form.tsx
+++ b/src/prefabs/form.tsx
@@ -218,6 +218,7 @@ const beforeCreate = ({
                       property,
                       variable,
                       result.relatedIdProperties,
+                      result.relatedModelIds,
                     ),
                   );
                   break;

--- a/src/prefabs/loginForm.tsx
+++ b/src/prefabs/loginForm.tsx
@@ -37,6 +37,7 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState(null);
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
+  const [permissions, setPermissions] = React.useState('public');
 
   const [endpoint, setEndpoint] = React.useState(null);
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);
@@ -133,6 +134,8 @@ const beforeCreate = ({
             null,
             'login',
             authProfile,
+            undefined,
+            permissions,
           );
 
           const structure = originalPrefab.structure[0];

--- a/src/prefabs/loginForm.tsx
+++ b/src/prefabs/loginForm.tsx
@@ -37,6 +37,7 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState(null);
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('public');
 
   const [endpoint, setEndpoint] = React.useState(null);

--- a/src/prefabs/loginForm.tsx
+++ b/src/prefabs/loginForm.tsx
@@ -6,6 +6,7 @@ import {
   prefab,
 } from '@betty-blocks/component-sdk';
 import { Form } from './structures/ActionJSForm';
+import { PermissionType } from './types/types';
 
 const beforeCreate = ({
   close,
@@ -38,7 +39,8 @@ const beforeCreate = ({
   const [authProfile, setAuthProfile] = React.useState(null);
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('public');
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('public');
 
   const [endpoint, setEndpoint] = React.useState(null);
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);

--- a/src/prefabs/loginForm.tsx
+++ b/src/prefabs/loginForm.tsx
@@ -38,14 +38,11 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState(null);
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('public');
-
   const [endpoint, setEndpoint] = React.useState(null);
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);
-
   const [model, setModel] = React.useState(null);
+
+  const permissions: PermissionType = 'public';
 
   const isEmptyEndpoint = (value): boolean =>
     !value || Object.keys(value).length === 0 || value.id === '';

--- a/src/prefabs/multiAutocomplete.tsx
+++ b/src/prefabs/multiAutocomplete.tsx
@@ -17,15 +17,10 @@ const beforeCreate = ({
     (option: { type: string }) => option.type === 'ACTION_JS_VARIABLE',
   );
 
-  // TODO: remove this code
-  if (!actionVariableOption) {
-    return <div>Prefab is missing the actionVariable component option</div>;
-  }
-
   return (
     <CreateFormInputWizard
       supportedKinds={['HAS_AND_BELONGS_TO_MANY', 'HAS_MANY']}
-      actionVariableOption={actionVariableOption.key}
+      actionVariableOption={actionVariableOption?.key || null}
       labelOptionKey="label"
       nameOptionKey="actionVariableId"
       close={close}
@@ -42,5 +37,9 @@ const attributes = {
 };
 
 export default prefab('Multi Autocomplete Beta', attributes, beforeCreate, [
-  MultiAutocomplete({ label: 'Autocomplete', type: 'text' }),
+  MultiAutocomplete({
+    label: 'Autocomplete',
+    inputLabel: 'Multi Autocomplete',
+    type: 'text',
+  }),
 ]);

--- a/src/prefabs/pageWithChecklist.tsx
+++ b/src/prefabs/pageWithChecklist.tsx
@@ -1,0 +1,1544 @@
+import * as React from 'react';
+
+import {
+  prefab as makePrefab,
+  Icon,
+  sizes,
+  variable,
+  option,
+  ThemeColor,
+  color,
+  font,
+  PrefabReference,
+  size,
+  showIf,
+  toggle,
+  showIfTrue,
+  component,
+  buttongroup,
+  PrefabInteraction,
+  icon,
+  hideIf,
+  BeforeCreateArgs,
+  PrefabComponent,
+  PrefabComponentOption,
+  text,
+} from '@betty-blocks/component-sdk';
+
+import {
+  AppBar,
+  appBarOptions,
+  Box,
+  boxOptions,
+  Button,
+  buttonOptions,
+  Column,
+  columnOptions,
+  DataList,
+  dataListOptions,
+  Grid,
+  gridOptions,
+  OpenPageButton,
+  openPageButtonOptions,
+  Row,
+  rowOptions,
+  Text,
+  textOptions,
+} from './structures';
+import { options as defaults } from './structures/ActionJSForm/options';
+import {
+  IdPropertyProps,
+  ModelProps,
+  ModelQuery,
+  PropertyStateProps,
+} from './types';
+
+const interactions = [
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#DropdownColumn',
+      sourceComponentId: '#DropdownButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#UpButton',
+      sourceComponentId: '#DropdownButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#DropdownButton',
+      sourceComponentId: '#DropdownButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#DropdownColumn',
+      sourceComponentId: '#UpButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#DropdownButton',
+      sourceComponentId: '#UpButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#UpButton',
+      sourceComponentId: '#UpButton',
+    },
+    type: 'Custom',
+  },
+  {
+    name: 'Submit',
+    sourceEvent: 'onChange',
+    ref: {
+      targetComponentId: '#formId',
+      sourceComponentId: '#checkBox',
+    },
+    type: 'Custom',
+  },
+] as PrefabInteraction[];
+
+const attrs = {
+  name: 'Checklist',
+  icon: Icon.DataList,
+  type: 'page',
+  description: 'This page contains a checklist based on your model',
+  detail:
+    'This page has a checklist for your model so you can check and uncheck items. Their status is being updated directly',
+  previewUrl: 'https://preview.betty.app/checklist',
+  previewImage:
+    'https://assets.bettyblocks.com/efaf005f4d3041e5bdfdd0643d1f190d_assets/files/Checklist',
+  category: 'LAYOUT',
+  interactions,
+};
+
+const prefabStructure = [
+  Row(
+    {
+      options: {
+        ...rowOptions,
+        maxRowWidth: option('CUSTOM', {
+          label: 'Width',
+          value: 'Full',
+          configuration: {
+            as: 'BUTTONGROUP',
+            dataType: 'string',
+            allowedInput: [
+              { name: 'S', value: 'S' },
+              { name: 'M', value: 'M' },
+              { name: 'L', value: 'L' },
+              { name: 'XL', value: 'XL' },
+              { name: 'Full', value: 'Full' },
+            ],
+          },
+        }),
+        rowHeight: text('Height', {
+          value: '100%',
+          configuration: {
+            as: 'UNIT',
+          },
+        }),
+      },
+    },
+    [
+      Column(
+        {
+          options: {
+            ...columnOptions,
+            columnWidth: option('CUSTOM', {
+              label: 'Column width',
+              value: '12',
+              configuration: {
+                as: 'DROPDOWN',
+                dataType: 'string',
+                allowedInput: [
+                  { name: 'Fit content', value: 'fitContent' },
+                  { name: 'Flexible', value: 'flexible' },
+                  { name: 'Hidden', value: 'hidden' },
+                  { name: '1', value: '1' },
+                  { name: '2', value: '2' },
+                  { name: '3', value: '3' },
+                  { name: '4', value: '4' },
+                  { name: '5', value: '5' },
+                  { name: '6', value: '6' },
+                  { name: '7', value: '7' },
+                  { name: '8', value: '8' },
+                  { name: '9', value: '9' },
+                  { name: '10', value: '10' },
+                  { name: '11', value: '11' },
+                  { name: '12', value: '12' },
+                ],
+              },
+            }),
+            columnWidthTabletLandscape: option('CUSTOM', {
+              label: 'Column width (tablet landscape)',
+              value: '12',
+              configuration: {
+                as: 'DROPDOWN',
+                dataType: 'string',
+                allowedInput: [
+                  { name: 'Fit content', value: 'fitContent' },
+                  { name: 'Flexible', value: 'flexible' },
+                  { name: 'Hidden', value: 'hidden' },
+                  { name: '1', value: '1' },
+                  { name: '2', value: '2' },
+                  { name: '3', value: '3' },
+                  { name: '4', value: '4' },
+                  { name: '5', value: '5' },
+                  { name: '6', value: '6' },
+                  { name: '7', value: '7' },
+                  { name: '8', value: '8' },
+                  { name: '9', value: '9' },
+                  { name: '10', value: '10' },
+                  { name: '11', value: '11' },
+                  { name: '12', value: '12' },
+                ],
+              },
+            }),
+            columnWidthTabletPortrait: option('CUSTOM', {
+              value: '12',
+              label: 'Column width (tablet portrait)',
+              configuration: {
+                as: 'DROPDOWN',
+                dataType: 'string',
+                allowedInput: [
+                  { name: 'Fit content', value: 'fitContent' },
+                  { name: 'Flexible', value: 'flexible' },
+                  { name: 'Hidden', value: 'hidden' },
+                  { name: '1', value: '1' },
+                  { name: '2', value: '2' },
+                  { name: '3', value: '3' },
+                  { name: '4', value: '4' },
+                  { name: '5', value: '5' },
+                  { name: '6', value: '6' },
+                  { name: '7', value: '7' },
+                  { name: '8', value: '8' },
+                  { name: '9', value: '9' },
+                  { name: '10', value: '10' },
+                  { name: '11', value: '11' },
+                  { name: '12', value: '12' },
+                ],
+              },
+            }),
+            columnWidthMobile: option('CUSTOM', {
+              value: 'flexible',
+              label: 'Column width (mobile)',
+              configuration: {
+                as: 'DROPDOWN',
+                dataType: 'string',
+                allowedInput: [
+                  { name: 'Fit content', value: 'fitContent' },
+                  { name: 'Flexible', value: 'flexible' },
+                  { name: 'Hidden', value: 'hidden' },
+                  { name: '1', value: '1' },
+                  { name: '2', value: '2' },
+                  { name: '3', value: '3' },
+                  { name: '4', value: '4' },
+                  { name: '5', value: '5' },
+                  { name: '6', value: '6' },
+                  { name: '7', value: '7' },
+                  { name: '8', value: '8' },
+                  { name: '9', value: '9' },
+                  { name: '10', value: '10' },
+                  { name: '11', value: '11' },
+                  { name: '12', value: '12' },
+                ],
+              },
+            }),
+            innerSpacing: sizes('Inner space', {
+              value: ['0rem', '0rem', '0rem', '0rem'],
+            }),
+            columnHeight: text('Height', {
+              value: '100%',
+              configuration: {
+                as: 'UNIT',
+              },
+            }),
+          },
+        },
+        [
+          Grid(
+            {
+              options: {
+                ...gridOptions,
+                height: size('Height', {
+                  value: '100%',
+                  configuration: {
+                    as: 'UNIT',
+                  },
+                }),
+              },
+            },
+            [
+              Grid(
+                {
+                  options: {
+                    ...gridOptions,
+                    height: size('Height', {
+                      value: '',
+                      configuration: {
+                        as: 'UNIT',
+                      },
+                    }),
+                    direction: option('CUSTOM', {
+                      value: 'column',
+                      label: 'Direction',
+                      configuration: {
+                        as: 'BUTTONGROUP',
+                        dataType: 'string',
+                        allowedInput: [
+                          { name: 'Horizontal', value: 'row' },
+                          { name: 'Vertical', value: 'column' },
+                        ],
+                        condition: showIf('type', 'EQ', 'container'),
+                      },
+                    }),
+                  },
+                },
+                [
+                  Box(
+                    {
+                      ref: { id: '#Header' },
+
+                      options: {
+                        ...boxOptions,
+                        innerSpacing: sizes('Inner space', {
+                          value: ['0rem', '0rem', '0rem', '0rem'],
+                        }),
+                      },
+                    },
+                    [
+                      Column(
+                        {
+                          options: {
+                            ...columnOptions,
+                            innerSpacing: sizes('Inner space', {
+                              value: ['0rem', '0rem', '0rem', '0rem'],
+                            }),
+                          },
+                        },
+                        [
+                          Box(
+                            {
+                              options: {
+                                ...boxOptions,
+                                innerSpacing: sizes('Inner space', {
+                                  value: ['0rem', '0rem', '0rem', '0rem'],
+                                }),
+                                backgroundOptions: toggle(
+                                  'Show background options',
+                                  {
+                                    value: true,
+                                  },
+                                ),
+                                backgroundColor: color('Background color', {
+                                  value: ThemeColor.PRIMARY,
+                                  configuration: {
+                                    condition: showIf(
+                                      'backgroundOptions',
+                                      'EQ',
+                                      true,
+                                    ),
+                                  },
+                                }),
+                              },
+                            },
+                            [
+                              Row({}, [
+                                Column(
+                                  {
+                                    options: {
+                                      ...columnOptions,
+                                      innerSpacing: sizes('Inner space', {
+                                        value: ['0rem', '0rem', '0rem', '0rem'],
+                                      }),
+                                    },
+                                  },
+                                  [
+                                    AppBar(
+                                      {
+                                        options: {
+                                          ...appBarOptions,
+                                          urlFileSource: variable('Source', {
+                                            value: [
+                                              'https://assets.bettyblocks.com/efaf005f4d3041e5bdfdd0643d1f190d_assets/files/Your_Logo_-_W.svg',
+                                            ],
+                                            configuration: {
+                                              placeholder:
+                                                'Starts with https:// or http://',
+                                              as: 'MULTILINE',
+                                              condition: showIf(
+                                                'type',
+                                                'EQ',
+                                                'url',
+                                              ),
+                                            },
+                                          }),
+                                          title: variable('Title', {
+                                            value: [],
+                                          }),
+                                        },
+                                      },
+                                      [
+                                        OpenPageButton(
+                                          {
+                                            style: {
+                                              overwrite: {
+                                                backgroundColor: {
+                                                  type: 'STATIC',
+                                                  value: 'transparent',
+                                                },
+                                                boxShadow: 'none',
+                                                color: {
+                                                  type: 'THEME_COLOR',
+                                                  value: 'white',
+                                                },
+                                                fontFamily: 'Roboto',
+                                                fontSize: '0.875rem',
+                                                fontStyle: 'none',
+                                                fontWeight: '400',
+                                                padding: ['0rem', '0rem'],
+                                                textDecoration: 'none',
+                                                textTransform: 'none',
+                                              },
+                                            },
+                                            options: {
+                                              ...openPageButtonOptions,
+                                              buttonText: variable(
+                                                'Button text',
+                                                {
+                                                  value: ['Menu 1'],
+                                                },
+                                              ),
+                                              outerSpacing: sizes(
+                                                'Outer space',
+                                                {
+                                                  value: [
+                                                    '0rem',
+                                                    'M',
+                                                    '0rem',
+                                                    'M',
+                                                  ],
+                                                },
+                                              ),
+                                            },
+                                          },
+                                          [],
+                                        ),
+                                        OpenPageButton(
+                                          {
+                                            style: {
+                                              overwrite: {
+                                                backgroundColor: {
+                                                  type: 'STATIC',
+                                                  value: 'transparent',
+                                                },
+                                                boxShadow: 'none',
+                                                color: {
+                                                  type: 'THEME_COLOR',
+                                                  value: 'white',
+                                                },
+                                                fontFamily: 'Roboto',
+                                                fontSize: '0.875rem',
+                                                fontStyle: 'none',
+                                                fontWeight: '400',
+                                                padding: ['0rem', '0rem'],
+                                                textDecoration: 'none',
+                                                textTransform: 'none',
+                                              },
+                                            },
+                                            options: {
+                                              ...openPageButtonOptions,
+                                              buttonText: variable(
+                                                'Button text',
+                                                {
+                                                  value: ['Menu 2'],
+                                                },
+                                              ),
+                                              outerSpacing: sizes(
+                                                'Outer space',
+                                                {
+                                                  value: [
+                                                    '0rem',
+                                                    'M',
+                                                    '0rem',
+                                                    '0rem',
+                                                  ],
+                                                },
+                                              ),
+                                            },
+                                          },
+                                          [],
+                                        ),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ]),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                  Box(
+                    {
+                      options: {
+                        ...boxOptions,
+                        stretch: toggle('Stretch (when in flex container)', {
+                          value: true,
+                        }),
+                        width: size('Width', {
+                          value: '100%',
+                          configuration: {
+                            as: 'UNIT',
+                          },
+                        }),
+                        innerSpacing: sizes('Inner space', {
+                          value: ['0rem', '0rem', '0rem', '0rem'],
+                        }),
+                        backgroundColor: color('Background color', {
+                          value: ThemeColor.LIGHT,
+                        }),
+                        backgroundColorAlpha: option('NUMBER', {
+                          label: 'Background color opacity',
+                          value: 20,
+                        }),
+                      },
+                    },
+                    [
+                      Row({}, [
+                        Column(
+                          {
+                            options: {
+                              ...columnOptions,
+                              innerSpacing: sizes('Inner space', {
+                                value: ['L', 'L', 'L', 'L'],
+                              }),
+                            },
+                          },
+                          [
+                            Text(
+                              {
+                                options: {
+                                  ...textOptions,
+                                  content: variable('Content', {
+                                    value: ['Page title'],
+                                    configuration: { as: 'MULTILINE' },
+                                  }),
+                                  type: font('Font', { value: ['Title5'] }),
+                                  outerSpacing: sizes('Outer space', {
+                                    value: ['M', '0rem', '0rem', '0rem'],
+                                  }),
+                                },
+                              },
+                              [],
+                            ),
+                            Text(
+                              {
+                                options: {
+                                  ...textOptions,
+                                  content: variable('Content', {
+                                    value: [
+                                      'Please add a subline here or just delete it if you want.',
+                                    ],
+                                    configuration: { as: 'MULTILINE' },
+                                  }),
+                                  type: font('Font', { value: ['Body1'] }),
+                                  outerSpacing: sizes('Outer space', {
+                                    value: ['M', '0rem', 'XL', '0rem'],
+                                  }),
+                                },
+                              },
+                              [],
+                            ),
+                            DataList(
+                              {
+                                options: {
+                                  ...dataListOptions,
+                                  pagination: option('CUSTOM', {
+                                    label: 'Pagination',
+                                    value: 'whenNeeded',
+                                    configuration: {
+                                      as: 'BUTTONGROUP',
+                                      dataType: 'string',
+                                      dependsOn: 'model',
+                                      allowedInput: [
+                                        { name: 'Always', value: 'always' },
+                                        {
+                                          name: 'When needed',
+                                          value: 'whenNeeded',
+                                        },
+                                        { name: 'Never', value: 'never' },
+                                      ],
+                                    },
+                                  }),
+                                },
+                                ref: {
+                                  id: '#dataList',
+                                },
+                              },
+                              [
+                                component(
+                                  'Form Beta',
+                                  {
+                                    label: 'Update Form Beta',
+                                    options: defaults,
+                                    ref: { id: '#formId' },
+                                  },
+                                  [
+                                    Box(
+                                      {
+                                        options: {
+                                          ...boxOptions,
+                                          outerSpacing: sizes('Outer space', {
+                                            value: [
+                                              '0rem',
+                                              '0rem',
+                                              'M',
+                                              '0rem',
+                                            ],
+                                          }),
+                                          innerSpacing: sizes('Inner space', {
+                                            value: ['0rem', 'M', '0rem', 'M'],
+                                          }),
+                                          backgroundColor: color(
+                                            'Background color',
+                                            {
+                                              value: ThemeColor.WHITE,
+                                            },
+                                          ),
+                                        },
+                                      },
+                                      [
+                                        Box(
+                                          {
+                                            options: {
+                                              ...boxOptions,
+                                              alignment: buttongroup(
+                                                'Alignment',
+                                                [
+                                                  ['None', 'none'],
+                                                  ['Left', 'flex-start'],
+                                                  ['Center', 'center'],
+                                                  ['Right', 'flex-end'],
+                                                  [
+                                                    'Justified',
+                                                    'space-between',
+                                                  ],
+                                                ],
+                                                {
+                                                  value: 'space-between',
+                                                  configuration: {
+                                                    dataType: 'string',
+                                                  },
+                                                },
+                                              ),
+                                              valignment: buttongroup(
+                                                'Vertical alignment',
+                                                [
+                                                  ['None', 'none'],
+                                                  ['Top', 'flex-start'],
+                                                  ['Center', 'center'],
+                                                  ['Bottom', 'flex-end'],
+                                                ],
+                                                {
+                                                  value: 'center',
+                                                  configuration: {
+                                                    dataType: 'string',
+                                                  },
+                                                },
+                                              ),
+                                              width: size('Width', {
+                                                value: '100%',
+                                                configuration: {
+                                                  as: 'UNIT',
+                                                },
+                                              }),
+                                              innerSpacing: sizes(
+                                                'Inner space',
+                                                {
+                                                  value: ['S', 'S', 'S', 'S'],
+                                                },
+                                              ),
+                                            },
+                                            ref: { id: '#formBox' },
+                                          },
+                                          [
+                                            Box(
+                                              {
+                                                options: {
+                                                  ...boxOptions,
+                                                  alignment: buttongroup(
+                                                    'Alignment',
+                                                    [
+                                                      ['None', 'none'],
+                                                      ['Left', 'flex-start'],
+                                                      ['Center', 'center'],
+                                                      ['Right', 'flex-end'],
+                                                      [
+                                                        'Justified',
+                                                        'space-between',
+                                                      ],
+                                                    ],
+                                                    {
+                                                      value: 'flex-end',
+                                                      configuration: {
+                                                        dataType: 'string',
+                                                      },
+                                                    },
+                                                  ),
+                                                  width: size('Width', {
+                                                    value: '25%',
+                                                    configuration: {
+                                                      as: 'UNIT',
+                                                    },
+                                                  }),
+                                                  innerSpacing: sizes(
+                                                    'Inner space',
+                                                    {
+                                                      value: [
+                                                        '0rem',
+                                                        '0rem',
+                                                        '0rem',
+                                                        '0rem',
+                                                      ],
+                                                    },
+                                                  ),
+                                                },
+                                              },
+                                              [
+                                                Button(
+                                                  {
+                                                    ref: {
+                                                      id: '#DropdownButton',
+                                                    },
+                                                    style: {
+                                                      overwrite: {
+                                                        backgroundColor: {
+                                                          type: 'STATIC',
+                                                          value: 'transparent',
+                                                        },
+                                                        boxShadow: 'none',
+                                                        color: {
+                                                          type: 'THEME_COLOR',
+                                                          value: 'black',
+                                                        },
+                                                        fontFamily: 'Roboto',
+                                                        fontSize: '0.875rem',
+                                                        fontStyle: 'none',
+                                                        fontWeight: '400',
+                                                        padding: [
+                                                          '0rem',
+                                                          '0rem',
+                                                        ],
+                                                        textDecoration: 'none',
+                                                        textTransform: 'none',
+                                                      },
+                                                    },
+                                                    options: {
+                                                      ...buttonOptions,
+                                                      buttonText: variable(
+                                                        'Button text',
+                                                        { value: [''] },
+                                                      ),
+                                                      icon: icon('Icon', {
+                                                        value:
+                                                          'KeyboardArrowDown',
+                                                      }),
+                                                      size: option('CUSTOM', {
+                                                        value: 'small',
+                                                        label: 'Icon size',
+                                                        configuration: {
+                                                          as: 'BUTTONGROUP',
+                                                          dataType: 'string',
+                                                          allowedInput: [
+                                                            {
+                                                              name: 'Small',
+                                                              value: 'small',
+                                                            },
+                                                            {
+                                                              name: 'Medium',
+                                                              value: 'medium',
+                                                            },
+                                                            {
+                                                              name: 'Large',
+                                                              value: 'large',
+                                                            },
+                                                          ],
+                                                          condition: hideIf(
+                                                            'icon',
+                                                            'EQ',
+                                                            'none',
+                                                          ),
+                                                        },
+                                                      }),
+                                                    },
+                                                  },
+                                                  [],
+                                                ),
+                                                Button(
+                                                  {
+                                                    ref: { id: '#UpButton' },
+                                                    style: {
+                                                      overwrite: {
+                                                        backgroundColor: {
+                                                          type: 'STATIC',
+                                                          value: 'transparent',
+                                                        },
+                                                        boxShadow: 'none',
+                                                        color: {
+                                                          type: 'THEME_COLOR',
+                                                          value: 'black',
+                                                        },
+                                                        fontFamily: 'Roboto',
+                                                        fontSize: '0.875rem',
+                                                        fontStyle: 'none',
+                                                        fontWeight: '400',
+                                                        padding: [
+                                                          '0rem',
+                                                          '0rem',
+                                                        ],
+                                                        textDecoration: 'none',
+                                                        textTransform: 'none',
+                                                      },
+                                                    },
+                                                    options: {
+                                                      ...buttonOptions,
+                                                      visible: toggle(
+                                                        'Toggle visibility',
+                                                        {
+                                                          value: false,
+                                                          configuration: {
+                                                            as: 'VISIBILITY',
+                                                          },
+                                                        },
+                                                      ),
+                                                      buttonText: variable(
+                                                        'Button text',
+                                                        { value: [''] },
+                                                      ),
+                                                      icon: icon('Icon', {
+                                                        value:
+                                                          'KeyboardArrowUp',
+                                                      }),
+                                                      size: option('CUSTOM', {
+                                                        value: 'small',
+                                                        label: 'Icon size',
+                                                        configuration: {
+                                                          as: 'BUTTONGROUP',
+                                                          dataType: 'string',
+                                                          allowedInput: [
+                                                            {
+                                                              name: 'Small',
+                                                              value: 'small',
+                                                            },
+                                                            {
+                                                              name: 'Medium',
+                                                              value: 'medium',
+                                                            },
+                                                            {
+                                                              name: 'Large',
+                                                              value: 'large',
+                                                            },
+                                                          ],
+                                                          condition: hideIf(
+                                                            'icon',
+                                                            'EQ',
+                                                            'none',
+                                                          ),
+                                                        },
+                                                      }),
+                                                    },
+                                                  },
+                                                  [],
+                                                ),
+                                              ],
+                                            ),
+                                          ],
+                                        ),
+                                        Row({}, [
+                                          Column(
+                                            {
+                                              ref: { id: '#DropdownColumn' },
+                                              options: {
+                                                ...columnOptions,
+                                                visible: toggle(
+                                                  'Toggle visibility',
+                                                  {
+                                                    value: false,
+                                                    configuration: {
+                                                      as: 'VISIBILITY',
+                                                    },
+                                                  },
+                                                ),
+                                                outerSpacing: sizes(
+                                                  'Outer space',
+                                                  {
+                                                    value: [
+                                                      '0rem',
+                                                      '0rem',
+                                                      '0rem',
+                                                      'L',
+                                                    ],
+                                                  },
+                                                ),
+                                              },
+                                            },
+                                            [
+                                              Text(
+                                                {
+                                                  ref: {
+                                                    id: '#descriptionText',
+                                                  },
+                                                  options: {
+                                                    ...textOptions,
+                                                    content: variable(
+                                                      'Content',
+                                                      {
+                                                        value: ['Description'],
+                                                        configuration: {
+                                                          as: 'MULTILINE',
+                                                        },
+                                                      },
+                                                    ),
+                                                    type: font('Font', {
+                                                      value: ['Body1'],
+                                                    }),
+                                                    textColor: color(
+                                                      'Text color',
+                                                      {
+                                                        value: ThemeColor.DARK,
+                                                      },
+                                                    ),
+                                                  },
+                                                },
+                                                [],
+                                              ),
+                                            ],
+                                          ),
+                                        ]),
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ]),
+                    ],
+                  ),
+                  Box(
+                    {
+                      ref: { id: '#Footer' },
+                      options: {
+                        ...boxOptions,
+                        width: size('Width', {
+                          value: '100%',
+                          configuration: {
+                            as: 'UNIT',
+                          },
+                        }),
+                        innerSpacing: sizes('Inner space', {
+                          value: ['0rem', '0rem', '0rem', '0rem'],
+                        }),
+                        backgroundColor: color('Background color', {
+                          value: ThemeColor.LIGHT,
+                          configuration: {
+                            condition: showIf('backgroundOptions', 'EQ', true),
+                          },
+                        }),
+                        backgroundColorAlpha: option('NUMBER', {
+                          label: 'Background color opacity',
+                          value: 20,
+                          configuration: {
+                            condition: showIf('backgroundOptions', 'EQ', true),
+                          },
+                        }),
+                      },
+                    },
+                    [
+                      Box(
+                        {
+                          options: {
+                            ...boxOptions,
+                            innerSpacing: sizes('Inner space', {
+                              value: ['L', 'L', 'L', 'L'],
+                            }),
+                          },
+                        },
+                        [
+                          Text(
+                            {
+                              options: {
+                                ...textOptions,
+                                content: variable('Content', {
+                                  value: ['Powered by Bettyblocks'],
+                                  configuration: { as: 'MULTILINE' },
+                                }),
+                                textAlignment: option('CUSTOM', {
+                                  label: 'Text Alignment',
+                                  value: 'center',
+                                  configuration: {
+                                    as: 'BUTTONGROUP',
+                                    dataType: 'string',
+                                    allowedInput: [
+                                      { name: 'Left', value: 'left' },
+                                      { name: 'Center', value: 'center' },
+                                      { name: 'Right', value: 'right' },
+                                    ],
+                                  },
+                                }),
+                                type: font('Font', { value: ['Body1'] }),
+                                styles: toggle('Styles', { value: true }),
+                                textColor: color('Text color', {
+                                  value: ThemeColor.MEDIUM,
+                                  configuration: {
+                                    condition: showIfTrue('styles'),
+                                  },
+                                }),
+                              },
+                            },
+                            [],
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ],
+      ),
+    ],
+  ),
+];
+
+const beforeCreate = ({
+  save,
+  close,
+  prefab: originalPrefab,
+  components: {
+    Header,
+    Content,
+    Field,
+    Footer,
+    Text: TextComp,
+    Box: BoxComp,
+    ModelSelector,
+    PropertySelector,
+    Button: ButtonComp,
+    PartialSelector,
+  },
+  helpers: {
+    useModelQuery,
+    prepareAction,
+    setOption,
+    makeBettyUpdateInput,
+    createUuid,
+    BettyPrefabs,
+  },
+}: BeforeCreateArgs) => {
+  const [showValidation, setShowValidation] = React.useState(false);
+  const [titleValidation, setTitleValidation] = React.useState(false);
+  const [descriptionValidation, setDescriptionValidation] =
+    React.useState(false);
+  const [checkBoxValidation, setCheckBoxValidation] = React.useState(false);
+  const [modelId, setModelId] = React.useState('');
+  const [model, setModel] = React.useState<ModelProps>();
+  const [titleProperty, setTitleProperty] = React.useState<PropertyStateProps>({
+    id: '',
+  });
+  const [descriptionProperty, setDescriptionProperty] =
+    React.useState<PropertyStateProps>({
+      id: '',
+    });
+  const [checkboxProperty, setCheckboxProperty] =
+    React.useState<PropertyStateProps>({
+      id: '',
+    });
+  const [idProperty, setIdProperty] = React.useState<IdPropertyProps>();
+  const [stepNumber, setStepNumber] = React.useState(1);
+  const [headerPartialId, setHeaderPartialId] = React.useState('');
+  const [footerPartialId, setFooterPartialId] = React.useState('');
+  const formId = createUuid();
+  const datalistId = createUuid();
+
+  const { data } = useModelQuery({
+    variables: { id: modelId },
+    skip: !modelId,
+    onCompleted: (result: ModelQuery) => {
+      setModel(result.model);
+      setIdProperty(result.model.properties.find(({ name }) => name === 'id'));
+    },
+  });
+
+  const treeSearch = (
+    dirName: string,
+    array: PrefabReference[],
+  ): PrefabComponent | undefined => {
+    // eslint-disable-next-line no-plusplus
+    for (let i = 0; i < array.length; i++) {
+      const q = array[i];
+      if (q.type === 'COMPONENT') {
+        if (q.ref && q.ref.id === dirName) {
+          return q;
+        }
+      }
+      if (q.type !== 'PARTIAL' && q.descendants && q.descendants.length) {
+        const result = treeSearch(dirName, q.descendants);
+        if (result) return result;
+      }
+    }
+    return undefined;
+  };
+
+  const enrichVarObj = (obj: any) => {
+    const returnObject = obj;
+    if (data && data.model) {
+      const property = data.model.properties.find(
+        (prop: any) => prop.id === obj.id[0],
+      );
+      if (property) {
+        returnObject.name = `{{ ${data.model.name}.${property.name} }}`;
+      }
+    }
+    return returnObject;
+  };
+
+  const stepper = {
+    setStep: (step: number) => {
+      if (step === 1) {
+        return (
+          <>
+            <BoxComp pad={{ bottom: '15px' }}>
+              <BoxComp pad={{ bottom: '15px' }}>
+                <TextComp size="medium" weight="bolder">
+                  Select partials
+                </TextComp>
+              </BoxComp>
+              <BoxComp pad={{ bottom: '15px' }}>
+                <TextComp color="grey700">
+                  By using a partial for the top menu and footer you can easily
+                  reuse the same structure without having to go through every
+                  page.
+                </TextComp>
+              </BoxComp>
+              <Field label="TOP MENU PARTIAL">
+                <PartialSelector
+                  label="Select a partial"
+                  onChange={(headerId: string) => {
+                    setHeaderPartialId(headerId);
+                  }}
+                  preSelected="Top menu"
+                  value={headerPartialId}
+                  allowedTypes={[
+                    'BODY_COMPONENT',
+                    'CONTAINER_COMPONENT',
+                    'CONTENT_COMPONENT',
+                  ]}
+                />
+              </Field>
+            </BoxComp>
+            <BoxComp pad={{ bottom: '15px' }}>
+              <Field label="FOOTER PARTIAL">
+                <PartialSelector
+                  label="Select a partial"
+                  onChange={(footerId: string) => {
+                    setFooterPartialId(footerId);
+                  }}
+                  preSelected="Footer"
+                  value={footerPartialId}
+                  allowedTypes={[
+                    'BODY_COMPONENT',
+                    'CONTAINER_COMPONENT',
+                    'CONTENT_COMPONENT',
+                  ]}
+                />
+              </Field>
+            </BoxComp>
+          </>
+        );
+      }
+      return (
+        <BoxComp direction="row">
+          <BoxComp direction="column" basis="2/3">
+            <Field
+              label="Select model"
+              error={
+                showValidation && (
+                  <TextComp color="#e82600">
+                    Selecting a model is required
+                  </TextComp>
+                )
+              }
+            >
+              <ModelSelector
+                onChange={(value: string) => {
+                  setShowValidation(false);
+                  setModelId(value);
+                  setTitleProperty({ id: '' });
+                  setDescriptionProperty({ id: '' });
+                  setCheckboxProperty({ id: '' });
+                }}
+                value={modelId}
+              />
+            </Field>
+            <hr />
+            {model && (
+              <>
+                <Field label="Title" info="Shows the title of Expansion Panel">
+                  <PropertySelector
+                    modelId={modelId}
+                    onChange={(value: PropertyStateProps) => {
+                      setTitleProperty(value);
+                    }}
+                    value={titleProperty}
+                    disabled={!modelId}
+                    error={
+                      titleValidation && (
+                        <TextComp color="#e82600">
+                          Selecting a title property is required
+                        </TextComp>
+                      )
+                    }
+                  />
+                </Field>
+                <Field
+                  label="Description"
+                  info="Shows the text within the Expansion Panel"
+                >
+                  <PropertySelector
+                    modelId={modelId}
+                    onChange={(value: PropertyStateProps) => {
+                      setDescriptionProperty(value);
+                    }}
+                    value={descriptionProperty}
+                    disabled={!modelId}
+                    error={
+                      descriptionValidation && (
+                        <TextComp color="#e82600">
+                          Selecting a description property is required
+                        </TextComp>
+                      )
+                    }
+                  />
+                </Field>
+                <Field
+                  label="Checklist checked"
+                  info="Checks if the value is true or false"
+                >
+                  <PropertySelector
+                    modelId={modelId}
+                    onChange={(value: PropertyStateProps) => {
+                      setCheckboxProperty(value);
+                    }}
+                    value={checkboxProperty}
+                    disabled={!modelId}
+                    error={
+                      checkBoxValidation && (
+                        <TextComp color="#e82600">
+                          Selecting a description property is required
+                        </TextComp>
+                      )
+                    }
+                    disabledKinds={[
+                      'AUTO_INCREMENT',
+                      'BOOLEAN_EXPRESSION',
+                      'COUNT',
+                      'DATE',
+                      'DATE_EXPRESSION',
+                      'DATE_TIME',
+                      'DATE_TIME_EXPRESSION',
+                      'DECIMAL',
+                      'DECIMAL_EXPRESSION',
+                      'EMAIL',
+                      'EMAIL_ADDRESS',
+                      'ENUM',
+                      'FILE',
+                      'FLOAT',
+                      'HAS_AND_BELONGS_TO_MANY',
+                      'HAS_MANY',
+                      'IBAN',
+                      'IMAGE',
+                      'INTEGER',
+                      'INTEGER_EXPRESSION',
+                      'LIST',
+                      'MINUTES',
+                      'MINUTES_EXPRESSION',
+                      'MULTI_FILE',
+                      'MULTI_IMAGE',
+                      'PASSWORD',
+                      'PDF',
+                      'PERIODIC_COUNT',
+                      'PHONE_NUMBER',
+                      'PRICE',
+                      'PRICE_EXPRESSION',
+                      'RICH_TEXT',
+                      'SERIAL',
+                      'SIGNED_PDF',
+                      'STRING',
+                      'STRING_EXPRESSION',
+                      'SUM',
+                      'TEXT',
+                      'TEXT_EXPRESSION',
+                      'TIME',
+                      'URL',
+                      'ZIPCODE',
+                    ]}
+                  />
+                </Field>
+              </>
+            )}
+          </BoxComp>
+        </BoxComp>
+      );
+    },
+    onSave: async () => {
+      // validation
+      if (!modelId) {
+        setShowValidation(true);
+        return;
+      }
+      if (!titleProperty.id) {
+        setTitleValidation(true);
+        return;
+      }
+      if (!descriptionProperty.id) {
+        setDescriptionValidation(true);
+        return;
+      }
+      if (!checkboxProperty.id) {
+        setCheckBoxValidation(true);
+        return;
+      }
+      const newPrefab = { ...originalPrefab };
+
+      // set datalist
+      const dataList = treeSearch('#dataList', newPrefab.structure);
+      if (!dataList) throw new Error('No dataList component found');
+
+      dataList.id = datalistId;
+      setOption(dataList, 'model', (opts) => ({
+        ...opts,
+        value: modelId,
+      }));
+
+      // set edit action
+      const transformProp = (obj: any) => {
+        const outputProp = obj;
+        outputProp.kind = 'BOOLEAN';
+        outputProp.defaultValue = {
+          __typename: 'DefaultValueType',
+          type: 'VALUE',
+          value: 'false',
+          expressionInfo: null,
+        };
+        if (data && data.model) {
+          const property = data.model.properties.find(
+            (prop: any) => prop.id === obj.id[0],
+          );
+          if (property) {
+            outputProp.label = property.label;
+          }
+        }
+        return outputProp;
+      };
+
+      if (model && idProperty && checkboxProperty) {
+        const editForm = treeSearch('#formId', newPrefab.structure);
+        if (!editForm) throw new Error('No editForm component found');
+
+        editForm.id = formId;
+        const result = await prepareAction(
+          formId,
+          idProperty,
+          [...transformProp(checkboxProperty)],
+          'update',
+        );
+        setOption(editForm, 'actionId', (opts: PrefabComponentOption) => ({
+          ...opts,
+          value: result.action.actionId,
+          configuration: { disabled: true },
+        }));
+        setOption(editForm, 'model', (opts: PrefabComponentOption) => ({
+          ...opts,
+          value: modelId,
+          configuration: {
+            disabled: true,
+          },
+        }));
+
+        Object.values(result.variables).forEach(([property, vari]) => {
+          const checkBoxInput = makeBettyUpdateInput(
+            BettyPrefabs.BOOLEAN,
+            model,
+            property,
+            vari,
+          );
+
+          if (checkBoxInput.type === 'COMPONENT') {
+            checkBoxInput.ref = { id: '#checkBox' };
+            setOption(
+              checkBoxInput,
+              'label',
+              (opts: PrefabComponentOption) => ({
+                ...opts,
+                value: [enrichVarObj(titleProperty)],
+              }),
+            );
+            setOption(
+              checkBoxInput,
+              'textColor',
+              (opts: PrefabComponentOption) => ({
+                ...opts,
+                value: 'Primary',
+              }),
+            );
+          }
+
+          setOption(editForm, 'filter', (opts: PrefabComponentOption) => ({
+            ...opts,
+            value: {
+              [idProperty.id]: {
+                eq: {
+                  id: [idProperty.id],
+                  type: 'PROPERTY',
+                  componentId: datalistId,
+                },
+              },
+            },
+          }));
+          const hiddenInput = makeBettyUpdateInput(
+            BettyPrefabs.HIDDEN,
+            model,
+            idProperty,
+            result.recordInputVariable,
+          );
+          const formBox = treeSearch('#formBox', newPrefab.structure);
+          if (!formBox) throw new Error('No form box component found');
+
+          formBox.descendants = [
+            checkBoxInput,
+            hiddenInput,
+            ...formBox.descendants,
+          ];
+        });
+      }
+
+      const descriptionText = treeSearch(
+        '#descriptionText',
+        newPrefab.structure,
+      );
+
+      if (descriptionText && descriptionProperty.id) {
+        setOption(
+          descriptionText,
+          'content',
+          (opts: PrefabComponentOption) => ({
+            ...opts,
+            value: [enrichVarObj(descriptionProperty)],
+          }),
+        );
+      }
+      const prefabFooter = treeSearch('#Footer', newPrefab.structure);
+      const prefabHeader = treeSearch('#Header', newPrefab.structure);
+      if (headerPartialId && prefabHeader) {
+        prefabHeader.descendants = [
+          { type: 'PARTIAL', partialId: headerPartialId },
+        ];
+      }
+
+      if (footerPartialId && prefabFooter) {
+        prefabFooter.descendants = [
+          { type: 'PARTIAL', partialId: footerPartialId },
+        ];
+      }
+
+      save(newPrefab);
+    },
+    buttons: () => (
+      <BoxComp direction="row" justify="between">
+        <BoxComp direction="row" margin="2rem">
+          <ButtonComp
+            label="Previous"
+            size="large"
+            background={{ color: '#f0f1f5' }}
+            onClick={() => {
+              if (stepNumber === 1) {
+                return;
+              }
+              const newStepnumber = stepNumber - 1;
+              setStepNumber(newStepnumber);
+            }}
+            margin={{ right: '5px' }}
+            disabled={stepNumber === 1}
+          />
+          <ButtonComp
+            label="Next"
+            size="large"
+            disabled={stepNumber === stepper.stepAmount}
+            onClick={() => {
+              const newStepnumber = stepNumber + 1;
+              setStepNumber(newStepnumber);
+            }}
+            primary
+          />
+        </BoxComp>
+        <BoxComp>
+          <Footer
+            onClose={close}
+            onSave={stepper.onSave}
+            canSave={stepNumber === stepper.stepAmount}
+          />
+        </BoxComp>
+      </BoxComp>
+    ),
+    progressBar: () => {
+      return (
+        <BoxComp
+          justify="center"
+          margin={{ left: '2rem', top: '-1rem', bottom: '-1rem' }}
+        >
+          <TextComp size="medium" weight="bold">{`Step: ${stepNumber + 1} / ${
+            stepper.stepAmount + 1
+          }`}</TextComp>
+        </BoxComp>
+      );
+    },
+    stepAmount: 2,
+  };
+  return (
+    <>
+      <Header onClose={close} title="Configure checklist page" />
+      {stepper.progressBar()}
+      <Content>{stepper.setStep(stepNumber)}</Content>
+      {stepper.buttons()}
+    </>
+  );
+};
+
+export default makePrefab('Checklist', attrs, beforeCreate, prefabStructure);

--- a/src/prefabs/pageWithChecklist.tsx
+++ b/src/prefabs/pageWithChecklist.tsx
@@ -52,6 +52,7 @@ import {
   ModelQuery,
   PropertyStateProps,
 } from './types';
+import { PermissionType } from './types/types';
 
 const interactions = [
   {
@@ -1056,6 +1057,7 @@ const beforeCreate = ({
   helpers: {
     useModelQuery,
     prepareAction,
+    getPageAuthenticationProfileId,
     setOption,
     makeBettyUpdateInput,
     createUuid,
@@ -1086,6 +1088,9 @@ const beforeCreate = ({
   const [footerPartialId, setFooterPartialId] = React.useState('');
   const formId = createUuid();
   const datalistId = createUuid();
+  const permissions: PermissionType = 'inherit';
+
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const { data } = useModelQuery({
     variables: { id: modelId },
@@ -1378,6 +1383,10 @@ const beforeCreate = ({
           idProperty,
           [...transformProp(checkboxProperty)],
           'update',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
         setOption(editForm, 'actionId', (opts: PrefabComponentOption) => ({
           ...opts,

--- a/src/prefabs/pageWithCrudDialogs.tsx
+++ b/src/prefabs/pageWithCrudDialogs.tsx
@@ -65,6 +65,7 @@ import {
   conditionalOptions,
 } from './structures';
 import { options as defaults } from './structures/ActionJSForm/options';
+import { PermissionType } from './types/types';
 
 const interactions: PrefabInteraction[] = [];
 
@@ -98,6 +99,7 @@ const beforeCreate = ({
   helpers: {
     createUuid,
     prepareAction,
+    getPageAuthenticationProfileId,
     PropertyKind,
     useModelQuery,
     cloneStructure,
@@ -126,6 +128,9 @@ const beforeCreate = ({
     },
     skip: !modelId,
   });
+
+  const permissions: PermissionType = 'inherit';
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const enrichVarObj = (obj: any) => {
     const returnObj = obj;
@@ -405,6 +410,10 @@ const beforeCreate = ({
         idProperty,
         properties,
         'create',
+        undefined,
+        undefined,
+        permissions,
+        pageAuthenticationProfileId,
       );
       Object.values(createResult.variables).forEach(
         ([prop, inputVariable]): void => {
@@ -671,6 +680,10 @@ const beforeCreate = ({
         idProperty,
         properties,
         'update',
+        undefined,
+        undefined,
+        permissions,
+        pageAuthenticationProfileId,
       );
       Object.values(updateResult.variables).forEach(
         ([prop, inputVariable]): void => {

--- a/src/prefabs/pageWithCrudSlideOutPanel.tsx
+++ b/src/prefabs/pageWithCrudSlideOutPanel.tsx
@@ -72,6 +72,7 @@ import {
 } from './structures';
 import { options as defaults } from './structures/ActionJSForm/options';
 import { IdPropertyProps, ModelProps, ModelQuery, Properties } from './types';
+import { PermissionType } from './types/types';
 
 const interactions: PrefabInteraction[] = [
   {
@@ -3050,6 +3051,7 @@ const beforeCreate = ({
   helpers: {
     useModelQuery,
     prepareAction,
+    getPageAuthenticationProfileId,
     cloneStructure,
     setOption,
     createUuid,
@@ -3075,6 +3077,8 @@ const beforeCreate = ({
   const [stepNumber, setStepNumber] = React.useState(1);
   const [headerPartialId, setHeaderPartialId] = React.useState('');
   const [footerPartialId, setFooterPartialId] = React.useState('');
+  const permissions: PermissionType = 'inherit';
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
 
   const createFormId = createUuid();
   const editFormId = createUuid();
@@ -3638,6 +3642,10 @@ const beforeCreate = ({
           idProperty,
           filteredproperties,
           'create',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
 
         Object.values(result.variables).forEach(
@@ -3860,6 +3868,10 @@ const beforeCreate = ({
           idProperty,
           filteredproperties,
           'update',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
         setOption(editForm, 'actionId', (opts: PrefabComponentOption) => ({
           ...opts,
@@ -4083,6 +4095,10 @@ const beforeCreate = ({
           idProperty,
           undefined,
           'delete',
+          undefined,
+          undefined,
+          permissions,
+          pageAuthenticationProfileId,
         );
 
         setOption(deleteForm, 'actionId', (opts: PrefabComponentOption) => ({

--- a/src/prefabs/pageWithLoginForm.tsx
+++ b/src/prefabs/pageWithLoginForm.tsx
@@ -44,6 +44,7 @@ import {
   openPageButtonOptions,
 } from './structures';
 import { AuthenticationProfile, Endpoint } from './types';
+import { PermissionType } from './types/types';
 
 const interactions: PrefabInteraction[] = [
   {
@@ -1008,7 +1009,8 @@ const beforeCreate = ({
   const [authProfile, setAuthProfile] = React.useState<AuthenticationProfile>();
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('public');
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('public');
 
   const [endpoint, setEndpoint] = React.useState<Endpoint>();
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);

--- a/src/prefabs/pageWithLoginForm.tsx
+++ b/src/prefabs/pageWithLoginForm.tsx
@@ -1008,9 +1008,7 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState<AuthenticationProfile>();
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('public');
+  const permissions: PermissionType = 'public';
 
   const [endpoint, setEndpoint] = React.useState<Endpoint>();
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);

--- a/src/prefabs/pageWithLoginForm.tsx
+++ b/src/prefabs/pageWithLoginForm.tsx
@@ -1007,6 +1007,7 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState<AuthenticationProfile>();
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
+  const [permissions, setPermissions] = React.useState('public');
 
   const [endpoint, setEndpoint] = React.useState<Endpoint>();
   const [endpointInvalid, setEndpointInvalid] = React.useState(false);
@@ -1178,6 +1179,8 @@ const beforeCreate = ({
             null,
             'login',
             authProfile,
+            undefined,
+            permissions,
           );
           if (authProfile) {
             if (authProfile.properties) {

--- a/src/prefabs/pageWithLoginForm.tsx
+++ b/src/prefabs/pageWithLoginForm.tsx
@@ -1007,6 +1007,7 @@ const beforeCreate = ({
   const [authProfileId, setAuthProfileId] = React.useState('');
   const [authProfile, setAuthProfile] = React.useState<AuthenticationProfile>();
   const [authProfileInvalid, setAuthProfileInvalid] = React.useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('public');
 
   const [endpoint, setEndpoint] = React.useState<Endpoint>();

--- a/src/prefabs/pageWithRegisterForm.tsx
+++ b/src/prefabs/pageWithRegisterForm.tsx
@@ -287,6 +287,7 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState<Properties[]>([]);
   const [showPropertiesValidation, setShowPropertiesValidation] =
     React.useState(false);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('public');
   const componentId = createUuid();
 

--- a/src/prefabs/pageWithRegisterForm.tsx
+++ b/src/prefabs/pageWithRegisterForm.tsx
@@ -287,6 +287,7 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState<Properties[]>([]);
   const [showPropertiesValidation, setShowPropertiesValidation] =
     React.useState(false);
+  const [permissions, setPermissions] = React.useState('public');
   const componentId = createUuid();
 
   useModelQuery({
@@ -474,6 +475,9 @@ const beforeCreate = ({
               idProperty,
               properties,
               'create',
+              undefined,
+              undefined,
+              permissions,
             );
             setOption(
               formPrefab,

--- a/src/prefabs/pageWithRegisterForm.tsx
+++ b/src/prefabs/pageWithRegisterForm.tsx
@@ -50,6 +50,7 @@ import {
 import { options as betaFormOptions } from './structures/ActionJSForm/options';
 import { Alert } from './structures/Alert/index';
 import { IdPropertyProps, ModelProps, ModelQuery, Properties } from './types';
+import { PermissionType } from './types/types';
 
 const interactions: PrefabInteraction[] = [
   {
@@ -288,7 +289,8 @@ const beforeCreate = ({
   const [showPropertiesValidation, setShowPropertiesValidation] =
     React.useState(false);
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('public');
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('public');
   const componentId = createUuid();
 
   useModelQuery({

--- a/src/prefabs/pageWithRegisterForm.tsx
+++ b/src/prefabs/pageWithRegisterForm.tsx
@@ -288,9 +288,7 @@ const beforeCreate = ({
   const [properties, setProperties] = React.useState<Properties[]>([]);
   const [showPropertiesValidation, setShowPropertiesValidation] =
     React.useState(false);
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('public');
+  const permissions: PermissionType = 'public';
   const componentId = createUuid();
 
   useModelQuery({

--- a/src/prefabs/radioinput.tsx
+++ b/src/prefabs/radioinput.tsx
@@ -18,14 +18,10 @@ const beforeCreate = ({
     (option: { type: string }) => option.type === 'ACTION_JS_VARIABLE',
   );
 
-  if (!actionVariableOption) {
-    return <div>Prefab is missing the actionVariable component option</div>;
-  }
-
   return (
     <CreateFormInputWizard
-      supportedKinds={['LIST']}
-      actionVariableOption={actionVariableOption.key}
+      supportedKinds={['LIST', 'BELONGS_TO']}
+      actionVariableOption={actionVariableOption?.key || null}
       labelOptionKey="label"
       nameOptionKey="actionVariableId"
       close={close}

--- a/src/prefabs/selectinput.tsx
+++ b/src/prefabs/selectinput.tsx
@@ -17,14 +17,10 @@ const beforeCreate = ({
     (option: { type: string }) => option.type === 'ACTION_JS_VARIABLE',
   );
 
-  if (!actionVariableOption) {
-    return <div>Prefab is missing the actionVariable component option</div>;
-  }
-
   return (
     <CreateFormInputWizard
       supportedKinds={['LIST', 'BELONGS_TO']}
-      actionVariableOption={actionVariableOption.key}
+      actionVariableOption={actionVariableOption?.key || null}
       labelOptionKey="label"
       nameOptionKey="actionVariableId"
       close={close}
@@ -43,5 +39,6 @@ const attributes = {
 export default prefab('Select Beta', attributes, beforeCreate, [
   SelectInput({
     label: 'Select',
+    inputLabel: 'Select',
   }),
 ]);

--- a/src/prefabs/structures/AutocompleteInput/options/advanced.ts
+++ b/src/prefabs/structures/AutocompleteInput/options/advanced.ts
@@ -1,5 +1,4 @@
 import {
-  option,
   showIf,
   variable,
   toggle,
@@ -25,10 +24,5 @@ export const advanced = {
   dataComponentAttribute: variable('Test attribute', {
     value: [],
     ...showOn('advancedSettings'),
-  }),
-  actionVariableId: option('ACTION_JS_VARIABLE', {
-    label: 'Action input variable',
-    value: '',
-    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
   }),
 };

--- a/src/prefabs/structures/AutocompleteInput/options/index.ts
+++ b/src/prefabs/structures/AutocompleteInput/options/index.ts
@@ -5,6 +5,7 @@ import {
   property,
   hideIf,
   showIf,
+  model,
 } from '@betty-blocks/component-sdk';
 
 import { advanced } from './advanced';
@@ -12,33 +13,57 @@ import { styles } from './styles';
 import { validation } from './validation';
 
 export const options = {
+  actionVariableId: option('ACTION_JS_VARIABLE', {
+    label: 'Action input variable',
+    value: '',
+    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
+  }),
   actionProperty: option('ACTION_JS_PROPERTY', {
     label: 'Property',
     value: '',
+    configuration: {
+      condition: hideIf('actionProperty', 'EQ', ''),
+    },
   }),
   label: variable('Label', { value: [] }),
   value: variable('Value', { value: [] }),
-  labelProperty: property('Label for options', {
+  optionType: buttongroup(
+    'Option type',
+    [
+      ['Model', 'model'],
+      ['Property', 'property'],
+      ['Variable', 'variable'],
+    ],
+    {
+      value: 'variable',
+      configuration: {
+        condition: showIf('optionType', 'EQ', 'never'),
+      },
+    },
+  ),
+  model: model('Model', {
     value: '',
-    configuration: { condition: showIf('optionType', 'EQ', 'model') },
-  }),
-  optionType: buttongroup('Option type', [['Model', 'model']], {
-    value: 'model',
     configuration: {
-      condition: showIf('optionType', 'EQ', 'never'),
+      condition: showIf('optionType', 'EQ', 'variable'),
     },
   }),
   filter: option('FILTER', {
     label: 'Filter for options',
     value: {},
     configuration: {
-      dependsOn: 'actionProperty',
-      condition: showIf('optionType', 'EQ', 'model'),
+      dependsOn: 'model',
+      condition: hideIf('optionType', 'EQ', 'property'),
     },
   }),
   orderBy: property('Order by for options', {
     value: '',
-    configuration: { condition: showIf('optionType', 'EQ', 'model') },
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
+  }),
+  labelProperty: property('Label for options', {
+    value: '',
+    configuration: {
+      condition: hideIf('optionType', 'EQ', 'property'),
+    },
   }),
   order: buttongroup(
     'Sort order',
@@ -47,6 +72,7 @@ export const options = {
       ['Descending', 'desc'],
     ],
     {
+      value: 'asc',
       configuration: {
         condition: hideIf('orderBy', 'EQ', ''),
       },

--- a/src/prefabs/structures/CheckboxInput/index.ts
+++ b/src/prefabs/structures/CheckboxInput/index.ts
@@ -1,0 +1,25 @@
+import { component, PrefabReference } from '@betty-blocks/component-sdk';
+import { Configuration } from '../Configuration';
+import {
+  checkboxInputOptions,
+  categories as defaultCategories,
+} from './options';
+
+export const CheckboxInput = (
+  config: Configuration,
+  descendants: PrefabReference[] = [],
+) => {
+  const options = { ...(config.options || checkboxInputOptions) };
+  const style = { ...config.style };
+  const ref = config.ref ? { ...config.ref } : undefined;
+  const label = config.label ? config.label : undefined;
+  const optionCategories = config.optionCategories
+    ? { ...config.optionCategories }
+    : defaultCategories;
+
+  return component(
+    'CheckboxInput',
+    { options, ref, style, label, optionCategories },
+    descendants,
+  );
+};

--- a/src/prefabs/structures/CheckboxInput/options/index.ts
+++ b/src/prefabs/structures/CheckboxInput/options/index.ts
@@ -1,0 +1,81 @@
+import {
+  option,
+  toggle,
+  text,
+  color,
+  ThemeColor,
+  showIfTrue,
+  variable,
+  showIf,
+} from '@betty-blocks/component-sdk';
+import { advanced } from '../../advanced';
+
+const stylesConfiguration = {
+  configuration: { condition: showIfTrue('styles') },
+};
+const validationConfiguration = {
+  configuration: { condition: showIfTrue('validationOptions') },
+};
+
+const validationOptions = {
+  validationOptions: toggle('Validation options'),
+  required: toggle('Required', validationConfiguration),
+  validationValueMissing: variable('Value required message', {
+    value: ['This field is required'],
+    ...validationConfiguration,
+  }),
+};
+
+export const categories = [
+  {
+    label: 'Advanced settings',
+    expanded: false,
+    members: ['dataComponentAttribute'],
+  },
+];
+
+export const checkboxInputOptions = {
+  actionProperty: option('ACTION_JS_PROPERTY', {
+    label: 'Property',
+    value: '',
+  }),
+  label: variable('Label', { value: ['Checkbox'] }),
+  value: variable('Value', { value: [] }),
+  ...validationOptions,
+  disabled: toggle('Disabled'),
+  helperText: variable('Helper text'),
+  actionVariableId: option('ACTION_JS_VARIABLE', { label: 'Name', value: '' }),
+  type: text('Type', {
+    value: 'checkbox',
+    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
+  }),
+  styles: toggle('Styles'),
+  checkboxColor: color('Checkbox color', {
+    ...stylesConfiguration,
+    value: ThemeColor.ACCENT_3,
+  }),
+  checkboxColorChecked: color('Checkbox color checked', {
+    ...stylesConfiguration,
+    value: ThemeColor.PRIMARY,
+  }),
+  textColor: color('Text color', {
+    ...stylesConfiguration,
+    value: ThemeColor.BLACK,
+  }),
+  helperColor: color('Helper color', {
+    ...stylesConfiguration,
+    value: ThemeColor.ACCENT_2,
+  }),
+  errorColor: color('Error color', {
+    ...stylesConfiguration,
+    value: ThemeColor.DANGER,
+  }),
+  validationOptions: toggle('Validation options'),
+  required: toggle('Required', validationConfiguration),
+  validationValueMissing: variable('Value required message', {
+    value: ['This field is required'],
+    ...validationConfiguration,
+  }),
+
+  ...advanced('CheckboxInput'),
+};

--- a/src/prefabs/structures/MultiAutoCompleteInput/index.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/index.ts
@@ -16,6 +16,10 @@ export const MultiAutocomplete = (
     options.type = updateOption(options.type, { value: config.type });
   }
 
+  if (config.inputLabel) {
+    options.label = updateOption(options.label, { value: [config.inputLabel] });
+  }
+
   if (config.adornmentIcon) {
     options.adornmentIcon = updateOption(options.adornmentIcon, {
       value: config.adornmentIcon,

--- a/src/prefabs/structures/MultiAutoCompleteInput/options/advanced.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/options/advanced.ts
@@ -1,9 +1,8 @@
 import {
-  option,
-  showIf,
-  variable,
-  toggle,
   buttongroup,
+  showIf,
+  toggle,
+  variable,
 } from '@betty-blocks/component-sdk';
 import { showOn } from '../../../../utils';
 
@@ -25,10 +24,5 @@ export const advanced = {
   dataComponentAttribute: variable('Test attribute', {
     value: [],
     ...showOn('advancedSettings'),
-  }),
-  actionVariableId: option('ACTION_JS_VARIABLE', {
-    label: 'Action input variable',
-    value: '',
-    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
   }),
 };

--- a/src/prefabs/structures/MultiAutoCompleteInput/options/index.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/options/index.ts
@@ -1,12 +1,12 @@
 import {
-  option,
-  variable,
   buttongroup,
-  property,
   hideIf,
+  model,
+  option,
+  property,
   showIf,
   toggle,
-  model,
+  variable,
 } from '@betty-blocks/component-sdk';
 
 import { advanced } from './advanced';
@@ -14,36 +14,57 @@ import { styles } from './styles';
 import { validation } from './validation';
 
 export const options = {
-  model: model('Related Model', {
+  actionVariableId: option('ACTION_JS_VARIABLE', {
+    label: 'Action input variable',
     value: '',
-    configuration: { condition: showIf('model', 'EQ', 'never') },
+    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
   }),
   actionProperty: option('ACTION_JS_PROPERTY', {
     label: 'Property',
     value: '',
+    configuration: {
+      condition: hideIf('actionProperty', 'EQ', ''),
+    },
   }),
   label: variable('Label', { value: [] }),
-  labelProperty: property('Label for options', {
+  value: variable('Value', { value: [] }),
+  optionType: buttongroup(
+    'Option type',
+    [
+      ['Model', 'model'],
+      ['Property', 'property'],
+      ['Variable', 'variable'],
+    ],
+    {
+      value: 'variable',
+      configuration: {
+        condition: showIf('optionType', 'EQ', 'never'),
+      },
+    },
+  ),
+  model: model('Model', {
     value: '',
-    configuration: { condition: showIf('optionType', 'EQ', 'model') },
-  }),
-  optionType: buttongroup('Option type', [['Model', 'model']], {
-    value: 'model',
     configuration: {
-      condition: showIf('optionType', 'EQ', 'never'),
+      condition: showIf('optionType', 'EQ', 'variable'),
     },
   }),
   filter: option('FILTER', {
     label: 'Filter for options',
     value: {},
     configuration: {
-      dependsOn: 'actionProperty',
-      condition: showIf('optionType', 'EQ', 'model'),
+      dependsOn: 'model',
+      condition: hideIf('optionType', 'EQ', 'property'),
     },
   }),
   orderBy: property('Order by for options', {
     value: '',
-    configuration: { condition: showIf('optionType', 'EQ', 'model') },
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
+  }),
+  labelProperty: property('Label for options', {
+    value: '',
+    configuration: {
+      condition: hideIf('optionType', 'EQ', 'property'),
+    },
   }),
   order: buttongroup(
     'Sort order',
@@ -52,6 +73,7 @@ export const options = {
       ['Descending', 'desc'],
     ],
     {
+      value: 'asc',
       configuration: {
         condition: hideIf('orderBy', 'EQ', ''),
       },

--- a/src/prefabs/structures/RadioInput/options/advanced.ts
+++ b/src/prefabs/structures/RadioInput/options/advanced.ts
@@ -1,4 +1,4 @@
-import { option, showIf, variable, toggle } from '@betty-blocks/component-sdk';
+import { variable, toggle } from '@betty-blocks/component-sdk';
 import { showOn } from '../../../../utils';
 
 export const advanced = {
@@ -6,15 +6,5 @@ export const advanced = {
   dataComponentAttribute: variable('Test attribute', {
     value: [],
     ...showOn('advancedSettings'),
-  }),
-  actionVariableId: option('ACTION_JS_VARIABLE', {
-    label: 'Action input variable',
-    value: '',
-    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
-  }),
-  propertyData: option('ACTION_JS_PROPERTY', {
-    label: 'propertyData',
-    value: '',
-    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
   }),
 };

--- a/src/prefabs/structures/RadioInput/options/index.ts
+++ b/src/prefabs/structures/RadioInput/options/index.ts
@@ -1,16 +1,92 @@
-import { option, variable } from '@betty-blocks/component-sdk';
+import {
+  hideIf,
+  showIf,
+  option,
+  variable,
+  buttongroup,
+  property,
+  filter,
+  model,
+} from '@betty-blocks/component-sdk';
 import { advanced } from './advanced';
 import { validation } from './validation';
 import { styles } from './styles';
 
 export const options = {
+  actionVariableId: option('ACTION_JS_VARIABLE', {
+    label: 'Action input variable',
+    value: '',
+    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
+  }),
   actionProperty: option('ACTION_JS_PROPERTY', {
     label: 'Property',
     value: '',
+    configuration: {
+      condition: hideIf('actionProperty', 'EQ', ''),
+    },
   }),
 
-  label: variable('Label', { value: [''] }),
+  label: variable('Label', { value: ['Radio'] }),
   value: variable('Value', { value: [''] }),
+
+  optionType: buttongroup(
+    'Option type',
+    [
+      ['Model', 'model'],
+      ['Property', 'property'],
+      ['Variable', 'variable'],
+    ],
+    {
+      value: 'variable',
+      configuration: {
+        condition: showIf('optionType', 'EQ', 'never'),
+      },
+    },
+  ),
+  model: model('Model', {
+    value: '',
+    configuration: {
+      condition: showIf('optionType', 'EQ', 'variable'),
+    },
+  }),
+  filter: filter('Filter', {
+    value: {},
+    configuration: {
+      dependsOn: 'model',
+      condition: hideIf('optionType', 'EQ', 'property'),
+    },
+  }),
+
+  orderBy: property('Order by', {
+    value: '',
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
+  }),
+
+  labelProperty: property('Label for options', {
+    value: '',
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
+  }),
+
+  order: buttongroup(
+    'Sort order',
+    [
+      ['Ascending', 'asc'],
+      ['Descending', 'desc'],
+    ],
+    { value: 'asc', configuration: { condition: hideIf('orderBy', 'EQ', '') } },
+  ),
+
+  showError: buttongroup(
+    'Error message',
+    [
+      ['Built in', 'built-in'],
+      ['Interaction', 'interaction'],
+    ],
+    {
+      value: 'built-in',
+      configuration: { condition: showIf('optionType', 'EQ', 'model') },
+    },
+  ),
   ...validation,
   ...styles,
   ...advanced,

--- a/src/prefabs/structures/SelectInput/options/advanced.ts
+++ b/src/prefabs/structures/SelectInput/options/advanced.ts
@@ -1,4 +1,4 @@
-import { option, showIf, variable, toggle } from '@betty-blocks/component-sdk';
+import { variable, toggle } from '@betty-blocks/component-sdk';
 import { showOn } from '../../../../utils';
 
 export const advanced = {
@@ -10,10 +10,5 @@ export const advanced = {
   dataComponentAttribute: variable('Test attribute', {
     value: [],
     ...showOn('advancedSettings'),
-  }),
-  actionVariableId: option('ACTION_JS_VARIABLE', {
-    label: 'Action input variable',
-    value: '',
-    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
   }),
 };

--- a/src/prefabs/structures/SelectInput/options/index.ts
+++ b/src/prefabs/structures/SelectInput/options/index.ts
@@ -6,44 +6,66 @@ import {
   property,
   showIf,
   variable,
+  model,
 } from '@betty-blocks/component-sdk';
 import { advanced } from './advanced';
 import { validation } from './validation';
 import { styles } from './styles';
 
 export const options = {
+  actionVariableId: option('ACTION_JS_VARIABLE', {
+    label: 'Action input variable',
+    value: '',
+    configuration: { condition: showIf('actionVariableId', 'EQ', 'never') },
+  }),
+
   actionProperty: option('ACTION_JS_PROPERTY', {
     label: 'Property',
     value: '',
+    configuration: {
+      condition: hideIf('actionProperty', 'EQ', ''),
+    },
   }),
 
-  label: variable('Label', { value: [''] }),
+  label: variable('Label', { value: ['Select'] }),
   value: variable('Value', { value: [''] }),
 
-  labelProperty: property('Label for options', {
+  optionType: buttongroup(
+    'Option type',
+    [
+      ['Model', 'model'],
+      ['Property', 'property'],
+      ['Variable', 'variable'],
+    ],
+    {
+      value: 'variable',
+      configuration: {
+        condition: showIf('optionType', 'EQ', 'never'),
+      },
+    },
+  ),
+  model: model('Model', {
     value: '',
-    configuration: { condition: showIf('optionType', 'EQ', 'model') },
-  }),
-
-  optionType: buttongroup('Option type', [['Model', 'model']], {
-    value: 'model',
     configuration: {
-      condition: showIf('optionType', 'EQ', 'never'),
+      condition: showIf('optionType', 'EQ', 'variable'),
     },
   }),
   filter: filter('Filter', {
     value: {},
     configuration: {
-      dependsOn: 'actionProperty',
-      condition: showIf('optionType', 'EQ', 'model'),
+      dependsOn: 'model',
+      condition: hideIf('optionType', 'EQ', 'property'),
     },
   }),
 
   orderBy: property('Order by', {
     value: '',
-    configuration: {
-      condition: showIf('optionType', 'EQ', 'model'),
-    },
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
+  }),
+
+  labelProperty: property('Label for options', {
+    value: '',
+    configuration: { condition: hideIf('optionType', 'EQ', 'property') },
   }),
 
   order: buttongroup(

--- a/src/prefabs/types/types.ts
+++ b/src/prefabs/types/types.ts
@@ -149,3 +149,5 @@ export declare enum AuthenticationProfileKind {
   customAuthentication = 'customAuthentication',
   usernamePassword = 'usernamePassword',
 }
+
+export type PermissionType = 'private' | 'public' | 'inherit';

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -75,6 +75,7 @@ const beforeCreate = ({
   });
   const [buttonGroupValue, setButtonGroupValue] = React.useState('anotherPage');
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const [permissions, setPermissions] = React.useState('private');
   const [validationMessage, setValidationMessage] = React.useState('');
   const [anotherPageState, setAnotherPageState] = React.useState({

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -56,6 +56,7 @@ const beforeCreate = ({
     createUuid,
     makeBettyUpdateInput,
     prepareAction,
+    getPageAuthenticationProfileId,
     useCurrentPartialId,
     useCurrentPageId,
     setOption,
@@ -74,6 +75,7 @@ const beforeCreate = ({
   });
   const [buttonGroupValue, setButtonGroupValue] = React.useState('anotherPage');
 
+  const [permissions, setPermissions] = React.useState('private');
   const [validationMessage, setValidationMessage] = React.useState('');
   const [anotherPageState, setAnotherPageState] = React.useState({
     modelId: '',
@@ -81,7 +83,7 @@ const beforeCreate = ({
   const pageId = useCurrentPageId();
   const partialId = useCurrentPartialId();
   const componentId = createUuid();
-
+  const pageAuthenticationProfileId = getPageAuthenticationProfileId();
   const modelRequest = useModelQuery({
     variables: { id: modelId },
     onCompleted: (result) => {
@@ -356,6 +358,10 @@ const beforeCreate = ({
             idProperty,
             properties,
             'update',
+            undefined,
+            undefined,
+            permissions,
+            pageAuthenticationProfileId,
           );
 
           setOption(structure, 'actionId', (option) => ({

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -76,9 +76,7 @@ const beforeCreate = ({
   });
   const [buttonGroupValue, setButtonGroupValue] = React.useState('anotherPage');
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] =
-    React.useState<PermissionType>('private');
+  const permissions: PermissionType = 'inherit';
   const [validationMessage, setValidationMessage] = React.useState('');
   const [anotherPageState, setAnotherPageState] = React.useState({
     modelId: '',

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -7,6 +7,7 @@ import {
   BeforeCreateArgs,
 } from '@betty-blocks/component-sdk';
 import { Form } from './structures/ActionJSForm';
+import { PermissionType } from './types/types';
 
 const beforeCreate = ({
   close,
@@ -76,7 +77,8 @@ const beforeCreate = ({
   const [buttonGroupValue, setButtonGroupValue] = React.useState('anotherPage');
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const [permissions, setPermissions] = React.useState('private');
+  const [permissions, setPermissions] =
+    React.useState<PermissionType>('private');
   const [validationMessage, setValidationMessage] = React.useState('');
   const [anotherPageState, setAnotherPageState] = React.useState({
     modelId: '',

--- a/src/prefabs/updateForm.tsx
+++ b/src/prefabs/updateForm.tsx
@@ -389,6 +389,7 @@ const beforeCreate = ({
                     property,
                     variable,
                     result.relatedIdProperties,
+                    result.relatedModelIds,
                   ),
                 );
                 break;

--- a/yarn.lock
+++ b/yarn.lock
@@ -199,9 +199,9 @@
     webhead "^1.1.3"
 
 "@betty-blocks/component-sdk@^1.29.0":
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/@betty-blocks/component-sdk/-/component-sdk-1.29.0.tgz#8ab4387391783c3b1eee221b8adc60b16dba5948"
-  integrity sha512-8onqhipUIm5v2xmeAwKfK0oyOxxNug0Sk6CD32yTcBzfSrwYA/SZkEw8jtAZPE7ieo8+OZGKnP2vjkZyigPF1w==
+  version "1.33.1"
+  resolved "https://registry.yarnpkg.com/@betty-blocks/component-sdk/-/component-sdk-1.33.1.tgz#c242dc8945dd7d4fbfc8e63e098533312c70fac5"
+  integrity sha512-T+P5uXqWOaPirYuhvCF/V09SHW19O0A7iQKwVVgvL1oPQy99KfnCalvkRX+yPd3zfSP8hpKvBxb8u/QSrkUVGA==
 
 "@colors/colors@1.5.0":
   version "1.5.0"


### PR DESCRIPTION
The prepareAction helper function supports two new arguments: permissions and pageAuthenticationProfileId.
Both arguments are used to generate permissions. When permission is set to 'private' it will set the action to private and generate a permission for the admin role, so it can execute.
The `inherit` key is used to generate an admin role based on the page authentication profile. If there is a page authentication profile, it will create a execute permission for the admin role.