### PR TITLE
fix: Change boolean to string for allowed_input.

### DIFF
--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -536,8 +536,8 @@ const drawerContainer = DrawerContainer(
               as: 'BUTTONGROUP',
               dataType: 'boolean',
               allowedInput: [
-                { name: 'Overview', value: false },
-                { name: 'Record view', value: true },
+                { name: 'Overview', value: 'false' },
+                { name: 'Record view', value: 'true' },
               ],
             },
             value: {

--- a/src/prefabs/pageWithCrudSlideOutPanel.tsx
+++ b/src/prefabs/pageWithCrudSlideOutPanel.tsx
@@ -593,8 +593,8 @@ const drawerContainer = DrawerContainer(
                                 configuration: {
                                   as: 'BUTTONGROUP',
                                   allowedInput: [
-                                    { name: 'Overview', value: false },
-                                    { name: 'Record view', value: true },
+                                    { name: 'Overview', value: 'false' },
+                                    { name: 'Record view', value: 'true' },
                                   ],
                                 },
                               }),


### PR DESCRIPTION
Currently the MetaAPI mutation schema only allows `strings` for the input-field `value`. This commit will change the boolean value to a string value.