### PR TITLE
feat: add interaction to set search parameters

### DIFF
--- a/src/interactions/setUrlParameter.ts
+++ b/src/interactions/setUrlParameter.ts
@@ -1,0 +1,23 @@
+/* eslint @typescript-eslint/no-unused-vars: ["error", { "varsIgnorePattern": "setUrlParam" }] */
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+interface History {
+  push(url: string): string;
+}
+
+function setUrlParameter({
+  event,
+  paramName,
+}: {
+  event: Event;
+  paramName: string;
+}): void {
+  if (typeof event !== 'string') {
+    return;
+  }
+  const search = (event as string).toLowerCase().trim();
+  const href = new URL(window.location.href);
+  href.searchParams.set(paramName, search);
+  // eslint-disable-next-line no-restricted-globals
+  history.push(href.search);
+}

--- a/src/prefabs/structures/TextInput/options/advanced.ts
+++ b/src/prefabs/structures/TextInput/options/advanced.ts
@@ -1,7 +1,10 @@
-import { variable } from '@betty-blocks/component-sdk';
+import { variable, text } from '@betty-blocks/component-sdk';
 
 export const advanced = {
   dataComponentAttribute: variable('Test attribute', {
     value: [],
+  }),
+  searchParam: text('Search variable name', {
+    value: [''],
   }),
 };


### PR DESCRIPTION
The combination of this interaction and the search paramater option adds or updates that search paramater with the value of the input component. 

This way it can be used to dynamically add search paramaters for endusers via the url to for example search on title OR description.