### PR TITLE
fix: setShowPagination (in case of "When needed") to false OR true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.76.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.76.0...v2.76.1) (2022-11-21)
+
+
+### Bug Fixes
+
+* add subview component to backoffice detail view ([59da846](https://github.com/bettyblocks/material-ui-component-set/commit/59da8467db843db006520164c7b115c45fbcc04c))
+
 # [2.76.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.75.0...v2.76.0) (2022-11-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.76.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.75.0...v2.76.0) (2022-11-21)
+
+
+### Features
+
+* Add onLoad interactions to the forms ([89f9113](https://github.com/bettyblocks/material-ui-component-set/commit/89f9113169f6dc60c491c99b6665adc4a90f0347))
+
 # [2.75.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.74.0...v2.75.0) (2022-11-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.77.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.76.1...v2.77.0) (2022-11-21)
+
+
+### Features
+
+* made changes based on the feedback ([cc17645](https://github.com/bettyblocks/material-ui-component-set/commit/cc17645c6a5bbbf1c5cc552c8f323eeaa4975b93))
+
 ## [2.76.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.76.0...v2.76.1) (2022-11-21)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.75.0",
+  "version": "2.76.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.76.1",
+  "version": "2.77.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.76.0",
+  "version": "2.76.1",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/dataList.js
+++ b/src/components/dataList.js
@@ -291,9 +291,7 @@
                 setShowPagination(false);
                 break;
               case 'whenNeeded':
-                if (rowsPerPage >= data.totalCount) {
-                  setShowPagination(false);
-                }
+                setShowPagination(rowsPerPage < data.totalCount);
                 break;
               case 'always':
               default:

--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -297,6 +297,105 @@ const interactions: PrefabInteraction[] = [
     },
     type: InteractionType.Custom,
   },
+  {
+    type: InteractionType.Custom,
+    name: 'Disable',
+    sourceEvent: 'onActionLoad',
+    ref: {
+      targetComponentId: '#createSubmitButton',
+      sourceComponentId: '#createForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Enable',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      targetComponentId: '#createSubmitButton',
+      sourceComponentId: '#createForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Disable',
+    sourceEvent: 'onActionLoad',
+    ref: {
+      targetComponentId: '#editSubmitButton',
+      sourceComponentId: '#updateForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Enable',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      targetComponentId: '#editSubmitButton',
+      sourceComponentId: '#updateForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Show',
+    sourceEvent: 'onActionError',
+    ref: {
+      targetComponentId: '#createAlertErrorId',
+      sourceComponentId: '#createForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Hide',
+    sourceEvent: 'onActionLoad',
+    ref: {
+      targetComponentId: '#createAlertErrorId',
+      sourceComponentId: '#createForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Show',
+    sourceEvent: 'onActionError',
+    ref: {
+      targetComponentId: '#editErrorAlert',
+      sourceComponentId: '#updateForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Hide',
+    sourceEvent: 'onActionLoad',
+    ref: {
+      targetComponentId: '#editErrorAlert',
+      sourceComponentId: '#updateForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Toggle loading state',
+    sourceEvent: 'onActionLoad',
+    ref: {
+      targetComponentId: '#deleteSubmitButton',
+      sourceComponentId: '#deleteForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Toggle loading state',
+    sourceEvent: 'onActionError',
+    ref: {
+      targetComponentId: '#deleteSubmitButton',
+      sourceComponentId: '#deleteForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Toggle loading state',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      targetComponentId: '#deleteSubmitButton',
+      sourceComponentId: '#deleteForm',
+    },
+  },
 ];
 
 const attributes = {
@@ -4395,6 +4494,7 @@ const beforeCreate = ({
 
         const deleteSubmitButton = cloneStructure('Submit Button');
         if (deleteSubmitButton.type === 'COMPONENT') {
+          deleteSubmitButton.ref = { id: '#deleteSubmitButton' };
           deleteSubmitButton.style = {
             overwrite: {
               backgroundColor: {

--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -26,6 +26,7 @@ import {
   wrapper,
   linked,
   childSelector,
+  showIfTrue,
 } from '@betty-blocks/component-sdk';
 
 import {
@@ -65,11 +66,13 @@ import {
   Tabs,
   tabsOptions,
   Text,
+  TextInput,
+  textInputOptions,
   textOptions,
 } from './structures';
 import { options as defaults } from './structures/ActionJSForm/options';
 import { Properties, IdPropertyProps, ModelProps, ModelQuery } from './types';
-import { PermissionType } from './types/types';
+import { PermissionType, PropertyStateProps } from './types/types';
 
 const interactions: PrefabInteraction[] = [
   {
@@ -294,6 +297,60 @@ const interactions: PrefabInteraction[] = [
     ref: {
       targetComponentId: '#updateForm',
       sourceComponentId: '#editSubmitButton',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchColumn',
+      sourceComponentId: '#searchButton',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchButtonActive',
+      sourceComponentId: '#searchButton',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchButton',
+      sourceComponentId: '#searchButton',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchButtonActive',
+      sourceComponentId: '#searchButtonActive',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Hide',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchColumn',
+      sourceComponentId: '#searchButtonActive',
+    },
+    type: InteractionType.Custom,
+  },
+  {
+    name: 'Show',
+    sourceEvent: 'Click',
+    ref: {
+      targetComponentId: '#searchButton',
+      sourceComponentId: '#searchButtonActive',
     },
     type: InteractionType.Custom,
   },
@@ -2465,12 +2522,12 @@ const drawerContainer = DrawerContainer(
                                                                 ),
                                                               innerSpacing:
                                                                 sizes(
-                                                                  'Outer space',
+                                                                  'Inner space',
                                                                   {
                                                                     value: [
                                                                       '0rem',
                                                                       '0rem',
-                                                                      'XL',
+                                                                      '0rem',
                                                                       '0rem',
                                                                     ],
                                                                   },
@@ -2512,65 +2569,640 @@ const drawerContainer = DrawerContainer(
                                                               },
                                                               [],
                                                             ),
-                                                            Button(
+                                                            Box(
                                                               {
                                                                 options: {
-                                                                  ...buttonOptions,
-                                                                  buttonText:
-                                                                    variable(
-                                                                      'Button text',
+                                                                  ...boxOptions,
+                                                                  innerSpacing:
+                                                                    sizes(
+                                                                      'Inner space',
                                                                       {
                                                                         value: [
-                                                                          'New',
+                                                                          'M',
+                                                                          '0rem',
+                                                                          'M',
+                                                                          'M',
                                                                         ],
                                                                       },
                                                                     ),
-                                                                  icon: icon(
-                                                                    'Icon',
-                                                                    {
-                                                                      value:
-                                                                        'Add',
-                                                                    },
-                                                                  ),
-                                                                },
-                                                                ref: {
-                                                                  id: '#createButton',
-                                                                },
-                                                                style: {
-                                                                  overwrite: {
-                                                                    backgroundColor:
-                                                                      {
-                                                                        type: 'THEME_COLOR',
-                                                                        value:
-                                                                          'primary',
-                                                                      },
-                                                                    boxShadow:
-                                                                      'none',
-                                                                    color: {
-                                                                      type: 'THEME_COLOR',
-                                                                      value:
-                                                                        'white',
-                                                                    },
-                                                                    fontFamily:
-                                                                      'Roboto',
-                                                                    fontSize:
-                                                                      '0.875rem',
-                                                                    fontStyle:
-                                                                      'none',
-                                                                    fontWeight:
-                                                                      '400',
-                                                                    padding: [
-                                                                      '0.6875rem',
-                                                                      '1.375rem',
-                                                                    ],
-                                                                    textDecoration:
-                                                                      'none',
-                                                                    textTransform:
-                                                                      'none',
-                                                                  },
                                                                 },
                                                               },
-                                                              [],
+                                                              [
+                                                                Button(
+                                                                  {
+                                                                    ref: {
+                                                                      id: '#searchButtonActive',
+                                                                    },
+                                                                    label:
+                                                                      'Active search button',
+                                                                    style: {
+                                                                      overwrite:
+                                                                        {
+                                                                          backgroundColor:
+                                                                            {
+                                                                              type: 'STATIC',
+                                                                              value:
+                                                                                'white',
+                                                                            },
+                                                                          boxShadow:
+                                                                            'none',
+                                                                          color:
+                                                                            {
+                                                                              type: 'THEME_COLOR',
+                                                                              value:
+                                                                                'primary',
+                                                                            },
+                                                                          fontFamily:
+                                                                            'Roboto',
+                                                                          fontSize:
+                                                                            '0.875rem',
+                                                                          fontStyle:
+                                                                            'none',
+                                                                          fontWeight:
+                                                                            '400',
+                                                                          padding:
+                                                                            [
+                                                                              '0.5rem',
+                                                                              '0.625rem',
+                                                                            ],
+                                                                          textDecoration:
+                                                                            'none',
+                                                                          textTransform:
+                                                                            'none',
+                                                                        },
+                                                                    },
+                                                                    options: {
+                                                                      ...buttonOptions,
+                                                                      visible:
+                                                                        toggle(
+                                                                          'Toggle visibility',
+                                                                          {
+                                                                            value:
+                                                                              false,
+                                                                            configuration:
+                                                                              {
+                                                                                as: 'VISIBILITY',
+                                                                              },
+                                                                          },
+                                                                        ),
+                                                                      buttonText:
+                                                                        variable(
+                                                                          'Button text',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                'Search',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                      icon: icon(
+                                                                        'Icon',
+                                                                        {
+                                                                          value:
+                                                                            'Search',
+                                                                        },
+                                                                      ),
+                                                                      outerSpacing:
+                                                                        sizes(
+                                                                          'Outer space',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                '0rem',
+                                                                                'XL',
+                                                                                '0rem',
+                                                                                '0rem',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                    },
+                                                                  },
+                                                                  [],
+                                                                ),
+                                                                Button(
+                                                                  {
+                                                                    ref: {
+                                                                      id: '#searchButton',
+                                                                    },
+                                                                    label:
+                                                                      'Search button',
+                                                                    style: {
+                                                                      overwrite:
+                                                                        {
+                                                                          backgroundColor:
+                                                                            {
+                                                                              type: 'STATIC',
+                                                                              value:
+                                                                                'transparent',
+                                                                            },
+                                                                          boxShadow:
+                                                                            'none',
+                                                                          color:
+                                                                            {
+                                                                              type: 'THEME_COLOR',
+                                                                              value:
+                                                                                'primary',
+                                                                            },
+                                                                          fontFamily:
+                                                                            'Roboto',
+                                                                          fontSize:
+                                                                            '0.875rem',
+                                                                          fontStyle:
+                                                                            'none',
+                                                                          fontWeight:
+                                                                            '400',
+                                                                          padding:
+                                                                            [
+                                                                              '0.5rem',
+                                                                              '0.625rem',
+                                                                            ],
+                                                                          textDecoration:
+                                                                            'none',
+                                                                          textTransform:
+                                                                            'none',
+                                                                        },
+                                                                    },
+                                                                    options: {
+                                                                      ...buttonOptions,
+                                                                      buttonText:
+                                                                        variable(
+                                                                          'Button text',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                'Search',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                      icon: icon(
+                                                                        'Icon',
+                                                                        {
+                                                                          value:
+                                                                            'Search',
+                                                                        },
+                                                                      ),
+                                                                      outerSpacing:
+                                                                        sizes(
+                                                                          'Outer space',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                '0rem',
+                                                                                'XL',
+                                                                                '0rem',
+                                                                                '0rem',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                    },
+                                                                  },
+                                                                  [],
+                                                                ),
+                                                                Button(
+                                                                  {
+                                                                    options: {
+                                                                      ...buttonOptions,
+                                                                      buttonText:
+                                                                        variable(
+                                                                          'Button text',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                'New',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                      icon: icon(
+                                                                        'Icon',
+                                                                        {
+                                                                          value:
+                                                                            'Add',
+                                                                        },
+                                                                      ),
+                                                                    },
+                                                                    ref: {
+                                                                      id: '#createButton',
+                                                                    },
+                                                                    style: {
+                                                                      overwrite:
+                                                                        {
+                                                                          backgroundColor:
+                                                                            {
+                                                                              type: 'THEME_COLOR',
+                                                                              value:
+                                                                                'primary',
+                                                                            },
+                                                                          boxShadow:
+                                                                            'none',
+                                                                          color:
+                                                                            {
+                                                                              type: 'THEME_COLOR',
+                                                                              value:
+                                                                                'white',
+                                                                            },
+                                                                          fontFamily:
+                                                                            'Roboto',
+                                                                          fontSize:
+                                                                            '0.875rem',
+                                                                          fontStyle:
+                                                                            'none',
+                                                                          fontWeight:
+                                                                            '400',
+                                                                          padding:
+                                                                            [
+                                                                              '0.6875rem',
+                                                                              '1.375rem',
+                                                                            ],
+                                                                          textDecoration:
+                                                                            'none',
+                                                                          textTransform:
+                                                                            'none',
+                                                                        },
+                                                                    },
+                                                                  },
+                                                                  [],
+                                                                ),
+                                                              ],
+                                                            ),
+                                                          ],
+                                                        ),
+                                                        Box(
+                                                          {
+                                                            options: {
+                                                              ...boxOptions,
+                                                              innerSpacing:
+                                                                sizes(
+                                                                  'Inner space',
+                                                                  {
+                                                                    value: [
+                                                                      '0rem',
+                                                                      '0rem',
+                                                                      'M',
+                                                                      '0rem',
+                                                                    ],
+                                                                  },
+                                                                ),
+                                                            },
+                                                          },
+                                                          [
+                                                            Column(
+                                                              {
+                                                                label:
+                                                                  'Search Column',
+                                                                ref: {
+                                                                  id: '#searchColumn',
+                                                                },
+                                                                options: {
+                                                                  ...columnOptions,
+                                                                  visible:
+                                                                    toggle(
+                                                                      'Toggle visibility',
+                                                                      {
+                                                                        value:
+                                                                          false,
+                                                                        configuration:
+                                                                          {
+                                                                            as: 'VISIBILITY',
+                                                                          },
+                                                                      },
+                                                                    ),
+                                                                  innerSpacing:
+                                                                    sizes(
+                                                                      'Inner space',
+                                                                      {
+                                                                        value: [
+                                                                          '0rem',
+                                                                          '0rem',
+                                                                          '0rem',
+                                                                          '0rem',
+                                                                        ],
+                                                                      },
+                                                                    ),
+                                                                },
+                                                              },
+                                                              [
+                                                                Box(
+                                                                  {
+                                                                    options: {
+                                                                      ...boxOptions,
+                                                                      innerSpacing:
+                                                                        sizes(
+                                                                          'Inner space',
+                                                                          {
+                                                                            value:
+                                                                              [
+                                                                                '0rem',
+                                                                                '0rem',
+                                                                                '0rem',
+                                                                                '0rem',
+                                                                              ],
+                                                                          },
+                                                                        ),
+                                                                      stretch:
+                                                                        toggle(
+                                                                          'Stretch (when in flex container)',
+                                                                          {
+                                                                            value:
+                                                                              true,
+                                                                          },
+                                                                        ),
+                                                                      position:
+                                                                        buttongroup(
+                                                                          'Position',
+                                                                          [
+                                                                            [
+                                                                              'Static',
+                                                                              'static',
+                                                                            ],
+                                                                            [
+                                                                              'Relative',
+                                                                              'relative',
+                                                                            ],
+                                                                            [
+                                                                              'Absolute',
+                                                                              'absolute',
+                                                                            ],
+                                                                            [
+                                                                              'Fixed',
+                                                                              'fixed',
+                                                                            ],
+                                                                            [
+                                                                              'Sticky',
+                                                                              'sticky',
+                                                                            ],
+                                                                          ],
+                                                                          {
+                                                                            value:
+                                                                              'relative',
+                                                                            configuration:
+                                                                              {
+                                                                                dataType:
+                                                                                  'string',
+                                                                              },
+                                                                          },
+                                                                        ),
+                                                                    },
+                                                                  },
+                                                                  [
+                                                                    TextInput(
+                                                                      {
+                                                                        label:
+                                                                          'Text field Beta',
+                                                                        inputLabel:
+                                                                          'Searchfield',
+                                                                        type: 'text',
+                                                                        ref: {
+                                                                          id: '#searchField',
+                                                                        },
+                                                                        options:
+                                                                          {
+                                                                            ...textInputOptions,
+                                                                            autoComplete:
+                                                                              toggle(
+                                                                                'Autocomplete',
+                                                                                {
+                                                                                  value:
+                                                                                    true,
+                                                                                },
+                                                                              ),
+                                                                            placeholder:
+                                                                              variable(
+                                                                                'Placeholder',
+                                                                                {
+                                                                                  value:
+                                                                                    [
+                                                                                      'Search',
+                                                                                    ],
+                                                                                },
+                                                                              ),
+                                                                            fullWidth:
+                                                                              toggle(
+                                                                                'Full width',
+                                                                                {
+                                                                                  value:
+                                                                                    true,
+                                                                                },
+                                                                              ),
+                                                                            styles:
+                                                                              toggle(
+                                                                                'Styles',
+                                                                                {
+                                                                                  value:
+                                                                                    true,
+                                                                                },
+                                                                              ),
+                                                                            hideLabel:
+                                                                              toggle(
+                                                                                'Hide label',
+                                                                                {
+                                                                                  value:
+                                                                                    true,
+                                                                                  configuration:
+                                                                                    {
+                                                                                      condition:
+                                                                                        showIfTrue(
+                                                                                          'styles',
+                                                                                        ),
+                                                                                    },
+                                                                                },
+                                                                              ),
+                                                                            margin:
+                                                                              buttongroup(
+                                                                                'Margin',
+                                                                                [
+                                                                                  [
+                                                                                    'None',
+                                                                                    'none',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Dense',
+                                                                                    'dense',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Normal',
+                                                                                    'normal',
+                                                                                  ],
+                                                                                ],
+                                                                                {
+                                                                                  value:
+                                                                                    'none',
+                                                                                },
+                                                                              ),
+                                                                          },
+                                                                      },
+                                                                      [],
+                                                                    ),
+                                                                    Box(
+                                                                      {
+                                                                        options:
+                                                                          {
+                                                                            ...boxOptions,
+                                                                            innerSpacing:
+                                                                              sizes(
+                                                                                'Inner space',
+                                                                                {
+                                                                                  value:
+                                                                                    [
+                                                                                      '0rem',
+                                                                                      '0rem',
+                                                                                      '0rem',
+                                                                                      '0rem',
+                                                                                    ],
+                                                                                },
+                                                                              ),
+                                                                            position:
+                                                                              buttongroup(
+                                                                                'Position',
+                                                                                [
+                                                                                  [
+                                                                                    'Static',
+                                                                                    'static',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Relative',
+                                                                                    'relative',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Absolute',
+                                                                                    'absolute',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Fixed',
+                                                                                    'fixed',
+                                                                                  ],
+                                                                                  [
+                                                                                    'Sticky',
+                                                                                    'sticky',
+                                                                                  ],
+                                                                                ],
+                                                                                {
+                                                                                  value:
+                                                                                    'absolute',
+                                                                                  configuration:
+                                                                                    {
+                                                                                      dataType:
+                                                                                        'string',
+                                                                                    },
+                                                                                },
+                                                                              ),
+                                                                            top: size(
+                                                                              'Top position',
+                                                                              {
+                                                                                value:
+                                                                                  '11px',
+                                                                                configuration:
+                                                                                  {
+                                                                                    as: 'UNIT',
+                                                                                  },
+                                                                              },
+                                                                            ),
+                                                                            right:
+                                                                              size(
+                                                                                'Right position',
+                                                                                {
+                                                                                  value:
+                                                                                    '11px',
+                                                                                  configuration:
+                                                                                    {
+                                                                                      as: 'UNIT',
+                                                                                    },
+                                                                                },
+                                                                              ),
+                                                                          },
+                                                                      },
+                                                                      [
+                                                                        Button(
+                                                                          {
+                                                                            ref: {
+                                                                              id: '#clearButton',
+                                                                            },
+                                                                            style:
+                                                                              {
+                                                                                overwrite:
+                                                                                  {
+                                                                                    borderRadius:
+                                                                                      [
+                                                                                        '3.125rem',
+                                                                                      ],
+                                                                                    boxShadow:
+                                                                                      'none',
+                                                                                    color:
+                                                                                      {
+                                                                                        type: 'THEME_COLOR',
+                                                                                        value:
+                                                                                          'white',
+                                                                                      },
+                                                                                    fontFamily:
+                                                                                      'Roboto',
+                                                                                    fontSize:
+                                                                                      '0.875rem',
+                                                                                    fontStyle:
+                                                                                      'none',
+                                                                                    fontWeight:
+                                                                                      '400',
+                                                                                    padding:
+                                                                                      [
+                                                                                        '0.375rem',
+                                                                                        '0.375rem',
+                                                                                      ],
+                                                                                    textDecoration:
+                                                                                      'none',
+                                                                                    textTransform:
+                                                                                      'none',
+                                                                                  },
+                                                                              },
+                                                                            options:
+                                                                              {
+                                                                                ...buttonOptions,
+                                                                                visible:
+                                                                                  toggle(
+                                                                                    'Toggle visibility',
+                                                                                    {
+                                                                                      value:
+                                                                                        false,
+                                                                                      configuration:
+                                                                                        {
+                                                                                          as: 'VISIBILITY',
+                                                                                        },
+                                                                                    },
+                                                                                  ),
+                                                                                buttonText:
+                                                                                  variable(
+                                                                                    'Button text',
+                                                                                    {
+                                                                                      value:
+                                                                                        [],
+                                                                                    },
+                                                                                  ),
+                                                                                outerSpacing:
+                                                                                  sizes(
+                                                                                    'Outer space',
+                                                                                    {
+                                                                                      value:
+                                                                                        [
+                                                                                          '0rem',
+                                                                                          '0rem',
+                                                                                          '0rem',
+                                                                                          '0rem',
+                                                                                        ],
+                                                                                    },
+                                                                                  ),
+                                                                                icon: icon(
+                                                                                  'Icon',
+                                                                                  {
+                                                                                    value:
+                                                                                      'Close',
+                                                                                  },
+                                                                                ),
+                                                                              },
+                                                                          },
+                                                                          [],
+                                                                        ),
+                                                                      ],
+                                                                    ),
+                                                                  ],
+                                                                ),
+                                                              ],
                                                             ),
                                                           ],
                                                         ),
@@ -3186,6 +3818,7 @@ const beforeCreate = ({
     Header,
     Field,
     Footer,
+    PropertySelector,
     ModelRelationSelector,
     PropertiesSelector,
     PartialSelector,
@@ -3225,6 +3858,9 @@ const beforeCreate = ({
   const [footerPartialId, setFooterPartialId] = React.useState('');
   const pageAuthenticationProfileId = getPageAuthenticationProfileId();
   const permissions: PermissionType = 'private';
+  const [searchProp, setSearchProp] = React.useState<PropertyStateProps>({
+    id: '',
+  });
 
   const createFormId = createUuid();
   const updateFormId = createUuid();
@@ -3547,6 +4183,48 @@ const beforeCreate = ({
                 setModelId(value);
               }}
               value={modelId}
+            />
+          </Field>
+          <Field label="Property used for the search field">
+            <PropertySelector
+              modelId={modelId}
+              onChange={(value: any) => {
+                setSearchProp(value);
+              }}
+              value={searchProp}
+              disabled={!modelId}
+              disabledKinds={[
+                'DATE',
+                'DATE_TIME',
+                'TIME',
+                'BELONGS_TO',
+                'HAS_AND_BELONGS_TO_MANY',
+                'HAS_MANY',
+                'MULTI_FILE',
+                'AUTO_INCREMENT',
+                'COUNT',
+                'MULTI_IMAGE',
+                'PDF',
+                'RICH_TEXT',
+                'SIGNED_PDF',
+                'SUM',
+                'BOOLEAN_EXPRESSION',
+                'DATE_EXPRESSION',
+                'DATE_TIME_EXPRESSION',
+                'DECIMAL_EXPRESSION',
+                'INTEGER_EXPRESSION',
+                'MINUTES_EXPRESSION',
+                'PRICE_EXPRESSION',
+                'STRING_EXPRESSION',
+                'TEXT_EXPRESSION',
+                'MINUTES',
+                'ZIPCODE',
+                'IMAGE',
+                'FILE',
+                'PASSWORD',
+                'SERIAL',
+              ]}
+              showFormat={false}
             />
           </Field>
           <Field
@@ -4602,6 +5280,63 @@ const beforeCreate = ({
             type: 'Global',
           } as PrefabInteraction,
         );
+      }
+      if (searchProp.id && searchProp.id !== '') {
+        if (newPrefab.interactions) {
+          newPrefab.interactions.push({
+            name: 'Filter',
+            sourceEvent: 'onChange',
+            parameters: [
+              {
+                id: [...searchProp.id],
+                operator: 'matches',
+                parameter: 'property',
+                resolveValue: false,
+              },
+            ],
+            ref: {
+              targetComponentId: '#dataTable',
+              sourceComponentId: '#searchField',
+            },
+            type: 'Custom',
+          } as PrefabInteraction);
+          newPrefab.interactions.push({
+            name: 'Show',
+            sourceEvent: 'onChange',
+            ref: {
+              targetComponentId: '#clearButton',
+              sourceComponentId: '#searchField',
+            },
+            type: 'Custom',
+          } as PrefabInteraction);
+          newPrefab.interactions.push({
+            name: 'Clear',
+            sourceEvent: 'Click',
+            ref: {
+              targetComponentId: '#searchField',
+              sourceComponentId: '#clearButton',
+            },
+            type: 'Custom',
+          } as PrefabInteraction);
+          newPrefab.interactions.push({
+            name: 'ResetFilter',
+            sourceEvent: 'Click',
+            ref: {
+              targetComponentId: '#dataTable',
+              sourceComponentId: '#clearButton',
+            },
+            type: 'Custom',
+          } as PrefabInteraction);
+          newPrefab.interactions.push({
+            name: 'Hide',
+            sourceEvent: 'Click',
+            ref: {
+              targetComponentId: '#clearButton',
+              sourceComponentId: '#clearButton',
+            },
+            type: 'Custom',
+          } as PrefabInteraction);
+        }
       }
       save(newPrefab);
     },

--- a/src/prefabs/backOfficeDetailsv2.tsx
+++ b/src/prefabs/backOfficeDetailsv2.tsx
@@ -367,9 +367,9 @@ const attributes = {
   icon: Icon.UpdateFormIcon,
   type: 'page',
   description:
-    'This page contains a detail view and all you need to update a record.',
+    'Within the detail view you can show and edit the specifications of a specific record.',
   detail:
-    'In this ready to use back office detail view, it is possible to display (read) and update a record.',
+    'Within the detail view you can show and edit the specifications of a specific record. Recommended to use in combination with the Back Office v2, overview.',
   previewUrl: 'https://preview-dev.app/back-office-details',
   previewImage:
     'https://assets.bettyblocks.com/63b1c6ccc6874e0796e5cc5b7e41b3da_assets/files/f1a4017ab78f41f38d1882f6b6cef37a',
@@ -2805,6 +2805,8 @@ const beforeCreate = ({
               idProperty,
               filteredproperties,
               'update',
+              undefined,
+              `Back office v2 - Update ${model.label}`,
             );
 
             const formInputStructure = (
@@ -3204,6 +3206,7 @@ const beforeCreate = ({
               undefined,
               'delete',
               undefined,
+              `Back office v2 - Delete ${model.label}`,
             );
             setOption(
               deleteForm,
@@ -4034,7 +4037,7 @@ const prefabStructure = [
 ];
 
 export default makePrefab(
-  'Back office v2 - Detail view',
+  'Back office v2, record view',
   attributes,
   beforeCreate,
   prefabStructure,

--- a/src/prefabs/backOfficeDetailsv2.tsx
+++ b/src/prefabs/backOfficeDetailsv2.tsx
@@ -56,6 +56,8 @@ import {
   FormErrorAlert,
   Divider,
   dataContainerOptions,
+  Subview,
+  subviewOptions,
 } from './structures';
 import { ModelProps, ModelQuery, IdPropertyProps } from './types';
 import { options as defaults } from './structures/ActionJSForm/options';
@@ -1742,6 +1744,141 @@ const drawerContainer = DrawerContainer(
                               ),
                             ],
                           ),
+                          Column(
+                            {
+                              options: {
+                                ...columnOptions,
+                                columnWidth: option('CUSTOM', {
+                                  label: 'Column width',
+                                  value: '4',
+                                  configuration: {
+                                    as: 'DROPDOWN',
+                                    dataType: 'string',
+                                    allowedInput: [
+                                      {
+                                        name: 'Fit content',
+                                        value: 'fitContent',
+                                      },
+                                      { name: 'Flexible', value: 'flexible' },
+                                      { name: 'Hidden', value: 'hidden' },
+                                      { name: '1', value: '1' },
+                                      { name: '2', value: '2' },
+                                      { name: '3', value: '3' },
+                                      { name: '4', value: '4' },
+                                      { name: '5', value: '5' },
+                                      { name: '6', value: '6' },
+                                      { name: '7', value: '7' },
+                                      { name: '8', value: '8' },
+                                      { name: '9', value: '9' },
+                                      { name: '10', value: '10' },
+                                      { name: '11', value: '11' },
+                                      { name: '12', value: '12' },
+                                    ],
+                                  },
+                                }),
+                                columnWidthTabletLandscape: option('CUSTOM', {
+                                  label: 'Column width (tablet landscape)',
+                                  value: '4',
+                                  configuration: {
+                                    as: 'DROPDOWN',
+                                    dataType: 'string',
+                                    allowedInput: [
+                                      {
+                                        name: 'Fit content',
+                                        value: 'fitContent',
+                                      },
+                                      { name: 'Flexible', value: 'flexible' },
+                                      { name: 'Hidden', value: 'hidden' },
+                                      { name: '1', value: '1' },
+                                      { name: '2', value: '2' },
+                                      { name: '3', value: '3' },
+                                      { name: '4', value: '4' },
+                                      { name: '5', value: '5' },
+                                      { name: '6', value: '6' },
+                                      { name: '7', value: '7' },
+                                      { name: '8', value: '8' },
+                                      { name: '9', value: '9' },
+                                      { name: '10', value: '10' },
+                                      { name: '11', value: '11' },
+                                      { name: '12', value: '12' },
+                                    ],
+                                  },
+                                }),
+                                columnWidthTabletPortrait: option('CUSTOM', {
+                                  value: '12',
+                                  label: 'Column width (tablet portrait)',
+                                  configuration: {
+                                    as: 'DROPDOWN',
+                                    dataType: 'string',
+                                    allowedInput: [
+                                      {
+                                        name: 'Fit content',
+                                        value: 'fitContent',
+                                      },
+                                      { name: 'Flexible', value: 'flexible' },
+                                      { name: 'Hidden', value: 'hidden' },
+                                      { name: '1', value: '1' },
+                                      { name: '2', value: '2' },
+                                      { name: '3', value: '3' },
+                                      { name: '4', value: '4' },
+                                      { name: '5', value: '5' },
+                                      { name: '6', value: '6' },
+                                      { name: '7', value: '7' },
+                                      { name: '8', value: '8' },
+                                      { name: '9', value: '9' },
+                                      { name: '10', value: '10' },
+                                      { name: '11', value: '11' },
+                                      { name: '12', value: '12' },
+                                    ],
+                                  },
+                                }),
+                                columnWidthMobile: option('CUSTOM', {
+                                  value: '12',
+                                  label: 'Column width (mobile)',
+                                  configuration: {
+                                    as: 'DROPDOWN',
+                                    dataType: 'string',
+                                    allowedInput: [
+                                      {
+                                        name: 'Fit content',
+                                        value: 'fitContent',
+                                      },
+                                      { name: 'Flexible', value: 'flexible' },
+                                      { name: 'Hidden', value: 'hidden' },
+                                      { name: '1', value: '1' },
+                                      { name: '2', value: '2' },
+                                      { name: '3', value: '3' },
+                                      { name: '4', value: '4' },
+                                      { name: '5', value: '5' },
+                                      { name: '6', value: '6' },
+                                      { name: '7', value: '7' },
+                                      { name: '8', value: '8' },
+                                      { name: '9', value: '9' },
+                                      { name: '10', value: '10' },
+                                      { name: '11', value: '11' },
+                                      { name: '12', value: '12' },
+                                    ],
+                                  },
+                                }),
+                                innerSpacing: sizes('Inner space', {
+                                  value: ['M', '0rem', 'M', 'M'],
+                                }),
+                              },
+                            },
+                            [
+                              Subview(
+                                {
+                                  options: {
+                                    ...subviewOptions,
+                                    backgroundColor: color('Background color', {
+                                      value: ThemeColor.WHITE,
+                                    }),
+                                  },
+                                },
+                                [],
+                              ),
+                            ],
+                          ),
                         ],
                       ),
                     ],
@@ -2659,7 +2796,8 @@ const beforeCreate = ({
               (prop) =>
                 prop.label !== 'Created at' &&
                 prop.label !== 'Updated at' &&
-                prop.label !== 'Id',
+                prop.label !== 'Id' &&
+                prop.kind !== 'PASSWORD',
             );
 
             const result = await prepareAction(

--- a/src/prefabs/backOfficev2.tsx
+++ b/src/prefabs/backOfficev2.tsx
@@ -354,9 +354,9 @@ const attributes = {
   icon: Icon.UpdateFormIcon,
   type: 'page',
   description:
-    'This page contains a datatable and all you need to manage your records.',
+    'Show a summary of the records of a selected data model, you can easily add records too.',
   detail:
-    'In this ready to use Data Table, it is possible to create and display (read) records. These functionalities are shown in a full page.',
+    'Show a summary of the records of a selected data model, you can easily add records too. Recommended to use in combination with the Back Office v2, record view.',
   previewUrl: 'https://preview.betty.app/back-office-v2',
   previewImage:
     'https://assets.bettyblocks.com/63b1c6ccc6874e0796e5cc5b7e41b3da_assets/files/ae140409957240c881669db9739f9f6e',
@@ -480,6 +480,38 @@ const beforeCreate = ({
                   }}
                   value={searchProp}
                   disabled={!modelId}
+                  disabledKinds={[
+                    'DATE',
+                    'DATE_TIME',
+                    'TIME',
+                    'BELONGS_TO',
+                    'HAS_AND_BELONGS_TO_MANY',
+                    'HAS_MANY',
+                    'MULTI_FILE',
+                    'AUTO_INCREMENT',
+                    'COUNT',
+                    'MULTI_IMAGE',
+                    'PDF',
+                    'RICH_TEXT',
+                    'SIGNED_PDF',
+                    'SUM',
+                    'BOOLEAN_EXPRESSION',
+                    'DATE_EXPRESSION',
+                    'DATE_TIME_EXPRESSION',
+                    'DECIMAL_EXPRESSION',
+                    'INTEGER_EXPRESSION',
+                    'MINUTES_EXPRESSION',
+                    'PRICE_EXPRESSION',
+                    'STRING_EXPRESSION',
+                    'TEXT_EXPRESSION',
+                    'MINUTES',
+                    'ZIPCODE',
+                    'IMAGE',
+                    'FILE',
+                    'PASSWORD',
+                    'SERIAL',
+                  ]}
+                  showFormat={false}
                 />
               </Field>
               <Field
@@ -786,6 +818,8 @@ const beforeCreate = ({
           idProperty,
           filteredproperties,
           'create',
+          undefined,
+          `Back office v2 - Create ${model.label}`,
         );
 
         Object.values(result.variables).forEach(
@@ -993,7 +1027,7 @@ const beforeCreate = ({
             parameters: [
               {
                 id: [...searchProp.id],
-                operator: 'regex',
+                operator: 'matches',
                 parameter: 'property',
                 resolveValue: false,
               },
@@ -3251,7 +3285,7 @@ const prefabStructure = [
 ];
 
 export default makePrefab(
-  'Back office v2 - Overview',
+  'Back office v2, overview',
   attributes,
   beforeCreate,
   prefabStructure,


### PR DESCRIPTION
In case you have a data list of 5 records and the pagination component option is set to "When needed" and the rows per page is equal to 5, no pagination is shown. When you add a new (6th) record via a form/action button and trigger a refetch on the data list, the pagination will now show up since you'll have two pages to show. On the contrary, when you have 6 records and delete one, the pagination will disappear.