### PR TITLE
fix: use correct format to set the default value

### DIFF
--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -109,14 +109,14 @@
       if (parsedValue) {
         switch (type) {
           case 'date': {
-            setSelectedDate(DateFns.parse(parsedValue, 'yyyy-MM-dd'));
+            setSelectedDate(DateFns.parse(parsedValue, dateFormat));
             break;
           }
 
           case 'datetime': {
             const formatDefaultParse = DateFns.parse(
               parsedValue,
-              'yyyy-MM-dd HH:mm:ss',
+              datetimeFormat,
             );
 
             if (!parsedValue) return;
@@ -131,7 +131,7 @@
           }
 
           case 'time': {
-            setSelectedDate(DateFns.parse(parsedValue, 'HH:mm:ss'));
+            setSelectedDate(DateFns.parse(parsedValue, timeFormat));
             break;
           }
 


### PR DESCRIPTION
When using a default value with the following format "MM-dd-yyyy" (which is the default that is set when dragging a datepicker on the canvas) the value is not shown. This is because the format in the parse helper function of DateFNS is hard-coded set to "yyyy-MM-dd" which does not match. This feature passes the format value from the component option to the parse helper function in order to work.