### PR TITLE
feat: make fetch policy configurable

### DIFF
--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -19,6 +19,7 @@
           filter,
           model,
           authProfile,
+          fetchPolicy,
           redirectWithoutResult,
           showError,
           currentRecord,
@@ -213,11 +214,7 @@
 
         if (model) {
           return (
-            <GetOne
-              modelId={model}
-              rawFilter={where}
-              fetchPolicy="cache-and-network"
-            >
+            <GetOne modelId={model} rawFilter={where} fetchPolicy={fetchPolicy}>
               {({ loading, error, data, refetch }) => {
                 if (!loading && data && data.id) {
                   B.triggerEvent('onSuccess', data);

--- a/src/prefabs/structures/DataContainer/options/advanced.ts
+++ b/src/prefabs/structures/DataContainer/options/advanced.ts
@@ -1,0 +1,19 @@
+import { variable, option } from '@betty-blocks/component-sdk';
+
+export const advanced = {
+  dataComponentAttribute: variable('Test attribute', {
+    value: ['Data container'],
+  }),
+  fetchPolicy: option('CUSTOM', {
+    value: 'cache-and-network',
+    label: 'Fetch Policy',
+    configuration: {
+      as: 'BUTTONGROUP',
+      dataType: 'string',
+      allowedInput: [
+        { name: 'Cache', value: 'cache-and-network' },
+        { name: 'No cache', value: 'no-cache' },
+      ],
+    },
+  }),
+};

--- a/src/prefabs/structures/DataContainer/options/index.ts
+++ b/src/prefabs/structures/DataContainer/options/index.ts
@@ -8,7 +8,7 @@ import {
   variable,
   authenticationProfile,
 } from '@betty-blocks/component-sdk';
-import { advanced } from '../../advanced';
+import { advanced } from './advanced';
 
 export const categories = [
   {
@@ -19,7 +19,7 @@ export const categories = [
   {
     label: 'Advanced Options',
     expanded: false,
-    members: ['dataComponentAttribute'],
+    members: ['dataComponentAttribute', 'fetchPolicy'],
   },
 ];
 
@@ -81,5 +81,5 @@ export const dataContainerOptions = {
     },
   }),
 
-  ...advanced('DataContainer'),
+  ...advanced,
 };


### PR DESCRIPTION
Hey! :wave: 

I've made the fetch policy configurable for a dataContainer component. This adds the following options under the advanced category:

- Cache => [cache-and-network](https://www.apollographql.com/docs/react/data/queries/#cache-and-network) (This was the default previously, and will still be used by default)
- No cache => [no-cache](https://www.apollographql.com/docs/react/data/queries/#no-cache)

![Screenshot from 2023-02-08 09-58-20](https://user-images.githubusercontent.com/78550663/217482654-9ed7b895-4ffa-4e8a-b208-cf5eb3926e56.png)

This way it stays simple for the no-coder, and backwards compatible if we do end up deciding to support more fetch policies.

This is to fix an issue a client is running into: [Ticket 2887](https://bettyblocks.atlassian.net/browse/PAGE-2882?atlOrigin=eyJpIjoiOTNhMzkxMzE1MWQ3NGZlZTg1OTM1YjhkYjIyNTRhZjkiLCJwIjoiaiJ9)
Read the comments of this ticket for more understanding why we chose to go with this fix: [Ticket 2887](https://bettyblocks.atlassian.net/browse/PAGE-2887?atlOrigin=eyJpIjoiNzhhYmFmMGE5Njk5NDcwZmFkMmE4NDY2Mzk2Mzg0NGEiLCJwIjoiaiJ9)

Let me know if there are any questions of feedback.