### PR TITLE
Feat/group by options autocomplete

### DIFF
--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -557,7 +557,7 @@
     };
 
     const getSortByGroupValue = (obj) =>
-      [obj].concat(group).reduce((a, b) => a && a[b]) || '';
+      [obj].concat(group).reduce((a, b) => a && a[b].toString()) || '';
 
     const currentOptions = getOptions();
     const currentOptionsGrouped =

--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -39,6 +39,7 @@
       minvalue,
       model,
       nameAttribute: nameAttributeRaw,
+      groupBy,
       order,
       orderBy,
       pattern,
@@ -272,6 +273,24 @@
 
     const searchPropIsNumber = numberPropTypes.includes(searchProp.kind);
     const valuePropIsNumber = numberPropTypes.includes(valueProp.kind);
+
+    /*
+     * Build up group array for grouping options
+     */
+    const idOrPathGroup =
+      typeof groupBy.id !== 'undefined' ? groupBy.id : groupBy;
+    const groupByPath =
+      typeof idOrPathGroup === 'string' ? [idOrPathGroup] : idOrPathGroup;
+
+    let group = [];
+
+    if (!isDev) {
+      if (groupByPath.length === 1 && groupByPath[0] !== '') {
+        group = [getProperty(groupByPath[0]).name];
+      } else if (groupByPath.length > 1) {
+        group = groupByPath.map((propertyId) => getProperty(propertyId).name);
+      }
+    }
 
     /*
      * We extend the option filter with the value of the `value` state and the value of the `inputValue` state.
@@ -537,7 +556,15 @@
       return [];
     };
 
+    const getSortByGroupValue = (obj) =>
+      [obj].concat(group).reduce((a, b) => a && a[b]) || '';
+
     const currentOptions = getOptions();
+    const currentOptionsGrouped =
+      group.length &&
+      currentOptions.sort(
+        (a, b) => -getSortByGroupValue(b).localeCompare(getSortByGroupValue(a)),
+      );
 
     /*
      * Convert `value` state into something the `value` prop of the `Autocomplete` component will accept with the right settings
@@ -635,6 +662,9 @@
           })}
           inputValue={inputValue}
           loading={loading}
+          {...(group.length && {
+            groupBy: (option) => getSortByGroupValue(option),
+          })}
           onChange={(_, newValue) => {
             setValue(newValue || '');
           }}
@@ -662,7 +692,7 @@
             handleValidation(validation);
             setInputValue('');
           }}
-          options={currentOptions}
+          options={currentOptionsGrouped || currentOptions}
           renderInput={(params) => (
             <>
               {!isListProperty && (

--- a/src/prefabs/structures/AutocompleteInput/options/index.ts
+++ b/src/prefabs/structures/AutocompleteInput/options/index.ts
@@ -55,6 +55,13 @@ export const options = {
       condition: hideIf('optionType', 'EQ', 'property'),
     },
   }),
+  groupBy: property('Group by for options', {
+    value: '',
+    configuration: {
+      dependsOn: 'model',
+      condition: hideIf('optionType', 'EQ', 'property'),
+    },
+  }),
   orderBy: property('Order by for options', {
     value: '',
     configuration: {


### PR DESCRIPTION
This feature enables you to group option values inside the autocomplete dropdown based on a (relational) property. It's a native feature of the MUI Autocomplete component, see https://mui.com/material-ui/react-autocomplete/#grouped. Use cases: you can group the options based on a specific type or status like grouping all cars based on their brand. The groups are always in alphabetical order, but you are still able to change the order of the options based on the sort option within each group.