### PR TITLE
Added capitals to validation for email input

### DIFF
--- a/src/prefabs/emailinput.tsx
+++ b/src/prefabs/emailinput.tsx
@@ -310,7 +310,7 @@ const attributes = {
   keywords: ['Form', 'input'],
 };
 
-const pattern = '[a-z0-9._%+-]+@[a-z0-9.-]+[\\.][a-z]{2,4}$';
+const pattern = '[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+[.][a-z]{2,4}$';
 
 export default prefab('Email', attributes, beforeCreate, [
   TextInput({


### PR DESCRIPTION
This new regex will also accept capitals in your email. For example: Firstname.Lastname@bettyblocks.com This was not the case with the previous regex. I've heard clients which also use capitals within their email address which walk into errors al the time.