### PR TITLE
feat: add theme weight to text component

### DIFF
--- a/src/components/text.js
+++ b/src/components/text.js
@@ -131,7 +131,11 @@
           `var(--text-fontSize-${type.toString().toLowerCase()})`,
         fontStyle: ({ options: { type } }) =>
           `var(--text-fontStyle-${type.toString().toLowerCase()})`,
-        fontWeight: ({ options: { fontWeight } }) => fontWeight,
+        fontWeight: ({ options }) => {
+          return options.fontWeight === '[Inherit]'
+            ? style.getFontWeight(options.type)
+            : options.fontWeight;
+        },
         textTransform: ({ options: { type } }) => style.getTextTransform(type),
         letterSpacing: ({ options: { type } }) => style.getLetterSpacing(type),
         [`@media ${mediaMinWidth(600)}`]: {

--- a/src/prefabs/structures/Text/options/index.ts
+++ b/src/prefabs/structures/Text/options/index.ts
@@ -102,6 +102,7 @@ export const textOptions = {
       as: 'DROPDOWN',
       dataType: 'string',
       allowedInput: [
+        { name: '[Theme Weight]', value: '[Inherit]' },
         { name: '100', value: '100' },
         { name: '200', value: '200' },
         { name: '300', value: '300' },


### PR DESCRIPTION
This was a feature request from Chris. There was already a branch for this, but the branch was outdated and it had a lot of changes which already were on production. https://github.com/bettyblocks/material-ui-component-set/pull/2782