### PR TITLE
fix: value not filled after dragged on update form

### DIFF
--- a/src/prefabs/ratingInput.tsx
+++ b/src/prefabs/ratingInput.tsx
@@ -254,10 +254,9 @@ const beforeCreate = ({
           if (validate()) {
             if (
               (selectedPrefab?.name === BettyPrefabs.UPDATE_FORM ||
-                ((selectedPrefab?.name === BettyPrefabs.CREATE_FORM ||
-                  selectedPrefab?.name === BettyPrefabs.FORM ||
-                  selectedPrefab?.name === BettyPrefabs.LOGIN_FORM) &&
-                  originalPrefab.name === BettyPrefabs.HIDDEN)) &&
+                selectedPrefab?.name === BettyPrefabs.CREATE_FORM ||
+                selectedPrefab?.name === BettyPrefabs.FORM ||
+                selectedPrefab?.name === BettyPrefabs.LOGIN_FORM) &&
               propertyId
             ) {
               const valueOptions = [


### PR DESCRIPTION
The prefab for the Rating component was using some outdated code, which meant the value in the options wouldn't be filled in, when the input was dragged onto a form.