### PR TITLE
Fix/richtext editor placeholder and helptext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.127.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.126.3...v2.127.0) (2023-04-19)
+
+
+### Features
+
+* add condition to actionVariableId ([6dbbbe1](https://github.com/bettyblocks/material-ui-component-set/commit/6dbbbe1c8e178a6e17e898bfb7d7e2850b6857e6))
+
 ## [2.126.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.126.2...v2.126.3) (2023-04-18)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.126.3",
+  "version": "2.127.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/richTextInput.js
+++ b/src/components/richTextInput.js
@@ -119,6 +119,8 @@
     const labelText = useText(label);
     const [showDropdown, setShowDropdown] = useState(false);
     const [activeStyleName, setActiveStyleName] = useState('Body 1');
+    const placeholderText = useText(placeholder);
+    const helperTextResolved = useText(helperText);
 
     const isMarkActive = (editor, format) => {
       const marks = Editor.marks(editor);
@@ -973,7 +975,9 @@
               renderLeaf={renderLeaf}
               renderElement={renderElement}
               placeholder={
-                <span className={classes.placeholderText}>{placeholder}</span>
+                <span className={classes.placeholderText}>
+                  {placeholderText}
+                </span>
               }
               readOnly={isDev || disabled}
               onKeyDown={(event) => {
@@ -983,9 +987,9 @@
           </Slate>
           <input type="hidden" name={name} value={currentValue} />
         </div>
-        {helperText && (
+        {helperTextResolved && (
           <FormHelperText classes={{ root: classes.helper }}>
-            {helperText}
+            {helperTextResolved}
           </FormHelperText>
         )}
       </div>
@@ -1080,7 +1084,7 @@
             '!important',
           ],
         },
-        margin: '0 14px !important',
+        margin: '3px 14px 0 !important',
       },
       toolbar: {
         padding: '16px 8px 0px 8px',

--- a/src/components/richTextInput.js
+++ b/src/components/richTextInput.js
@@ -1072,6 +1072,9 @@
           backgroundColor: '#eee',
           padding: '3px',
         },
+        '& [data-slate-placeholder]': {
+          width: ['auto', '!important'],
+        },
       },
       helper: {
         color: ({ options: { helperColor } }) => [


### PR DESCRIPTION
This resolves the issue of the richtext input component that breaks when a translation or property value is used in the placeholder or helper text variable options. In addition, there is a margin top of 3px added to the helper text to make it consistent with all the other input components.