### PR TITLE
fix: preload data in design time or option is true

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -157,7 +157,7 @@
                 showAllTabs={showAllTabs}
                 setSelectedTab={setSelectedTab}
                 activeTabs={activeTabs}
-                preLoadTabs={preLoadTabs}
+                preLoadTabs={isDev || preLoadTabs}
               >
                 {React.cloneElement(child, { ...childOptions })}
               </Children>


### PR DESCRIPTION
In design time you always want to see the child components of the tabs.

https://bettyblocks.atlassian.net/browse/PAGE-3378