### PR TITLE
Fix for the horizontal scrollbars

### DIFF
--- a/src/components/selectInput.js
+++ b/src/components/selectInput.js
@@ -567,6 +567,10 @@
                 },
             },
           },
+        '& [aria-hidden="true"].MuiSelect-nativeInput': {
+          width: 0,
+          height: 0,
+        },
       },
       clearLabel: {
         fontStyle: 'italic',


### PR DESCRIPTION
Currently when using the margin none option and dragging the select in a column the column get's horizontal scrollbars because of the hidden input where the value is set is wider then the select itself. This change fixes this issue.