### PR TITLE
feat: remove betty-jwt cookie, when logging in via user/password

### DIFF
--- a/src/interactions/login.ts
+++ b/src/interactions/login.ts
@@ -34,7 +34,7 @@ function login({
 
     const d = new Date();
     const e = d.toUTCString();
-    document.cookie = `betty_jwt=dummy; expires=${e}; SameSite=None`;
+    document.cookie = `betty_jwt=none; expires=${e}; SameSite=None`;
 
     localStorage.setItem('TOKEN', jwtToken);
     localStorage.setItem('REFRESH_TOKEN', refreshToken);

--- a/src/interactions/login.ts
+++ b/src/interactions/login.ts
@@ -32,6 +32,10 @@ function login({
       document.cookie = `BBLocale=${decodedToken.locale};path=/`;
     }
 
+    const d = new Date();
+    const e = d.toUTCString();
+    document.cookie = `betty_jwt=dummy; expires=${e}; SameSite=None`;
+
     localStorage.setItem('TOKEN', jwtToken);
     localStorage.setItem('REFRESH_TOKEN', refreshToken);
     // eslint-disable-next-line no-restricted-globals


### PR DESCRIPTION
Allowing to login via only one profile at a time, will prevent confusion in the /me-query. This query would often use the wrong keys, when multiple keys were present, and show unexpected behaviour.