### PR TITLE
feat: Store datetime in ISO-format

### DIFF
--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -171,7 +171,7 @@
         use24HourClock = use24HourClockDateTime;
 
         resultString = isValidDate(selectedDate)
-          ? DateFns.format(selectedDate, 'yyyy-MM-dd HH:mm:ss')
+          ? selectedDate.toISOString()
           : null;
         break;
       }


### PR DESCRIPTION
The ISO-format contains timezone information.
This will solve a bug where entering a datetime in a browser in another timezone as the server, would result in a timejump when requesting the datetime.