### PR TITLE
fix: conditional can handle empty values

### DIFF
--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -20,6 +20,7 @@
 
     const canBeNumber = (value) => {
       return (
+        value !== '' &&
         (typeof value === 'string' || typeof value === 'number') &&
         !isNaN(value)
       );
@@ -34,14 +35,14 @@
     const logic = useLogic(displayLogic);
 
     const evalCondition = () => {
+      if (!initVisibility && leftValue === '' && rightValue === '') {
+        return false;
+      }
+
       const [leftParsed, rightParsed] =
         canBeNumber(leftValue) && canBeNumber(rightValue)
           ? [parseFloat(leftValue), parseFloat(rightValue)]
           : [leftValue.toString(), rightValue.toString()];
-
-      if (!initVisibility && leftValue === '' && rightValue === '') {
-        return false;
-      }
 
       switch (compare) {
         case 'neq':


### PR DESCRIPTION
Comparing empty with empty (when both left- and righthand side are empty) would result in `false`, instead of `true`. This was because JS is stupid, and said that an empty string can be converted to a number, but then returned a `nil`.