### PR TITLE
feat: add option to show text when no results fetched PFR-697

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [2.157.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.157.0...v2.157.1) (2023-07-28)
+
+
+### Bug Fixes
+
+* add object prop type to allowedValues in multi autocomplete ([b6eeae5](https://github.com/bettyblocks/material-ui-component-set/commit/b6eeae538ea986286c039462b81078609b04c074))
+* pipelines ([94f4fe2](https://github.com/bettyblocks/material-ui-component-set/commit/94f4fe2d39b206691d26742813d4202dce6a5ec9))
+* set width of hidden input to 0px ([340901c](https://github.com/bettyblocks/material-ui-component-set/commit/340901c8b6b9b3dfa2536a578892d1d8fabdec3e))
+
 ## [2.157.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.157.0...v2.157.1) (2023-07-25)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [2.157.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.157.0...v2.157.1) (2023-07-31)
+
+
+### Bug Fixes
+
+* add debounced current value ([da53a4b](https://github.com/bettyblocks/material-ui-component-set/commit/da53a4b6606634210848aa3710af0ad11410bd96))
+* add object prop type to allowedValues in multi autocomplete ([b6eeae5](https://github.com/bettyblocks/material-ui-component-set/commit/b6eeae538ea986286c039462b81078609b04c074))
+* check values on json stringify format ([96cd7d9](https://github.com/bettyblocks/material-ui-component-set/commit/96cd7d9c691f863121766df0d0dea13c45d3abd0))
+* pipelines ([94f4fe2](https://github.com/bettyblocks/material-ui-component-set/commit/94f4fe2d39b206691d26742813d4202dce6a5ec9))
+* set width of hidden input to 0px ([340901c](https://github.com/bettyblocks/material-ui-component-set/commit/340901c8b6b9b3dfa2536a578892d1d8fabdec3e))
+
 ## [2.157.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.157.0...v2.157.1) (2023-07-28)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.157.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.157.0...v2.157.1) (2023-07-25)
+
+
+### Bug Fixes
+
+* pipelines ([94f4fe2](https://github.com/bettyblocks/material-ui-component-set/commit/94f4fe2d39b206691d26742813d4202dce6a5ec9))
+* set width of hidden input to 0px ([340901c](https://github.com/bettyblocks/material-ui-component-set/commit/340901c8b6b9b3dfa2536a578892d1d8fabdec3e))
+
 # [2.157.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.156.2...v2.157.0) (2023-07-24)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.157.0",
+  "version": "2.157.1",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/dataList.js
+++ b/src/components/dataList.js
@@ -35,6 +35,7 @@
           pagination,
           loadingType,
           loadingText,
+          noResultsText,
           dataComponentAttribute,
         } = options;
 
@@ -43,6 +44,7 @@
         const { label: searchPropertyLabel } =
           getProperty(searchProperty) || {};
         const parsedLoadingText = useText(loadingText);
+        const parsedNoResultsText = useText(noResultsText);
         const dataComponentAttributeText = useText(dataComponentAttribute);
         const isEmpty = children.length === 0;
         const isDev = env === 'dev';
@@ -438,6 +440,10 @@
 
           const { results = [], totalCount } = data || {};
           const resultCount = results && results.length;
+
+          if (!resultCount) {
+            return <span>{parsedNoResultsText}</span>;
+          }
 
           return (
             <div data-component={dataComponentAttributeText || 'DataContainer'}>

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -500,7 +500,7 @@
 
       if (results.length === 0 && parsedNoResultsText) {
         return (
-          <TableRow classes={{ root: classes.bodyRow }}>
+          <TableRow>
             <TableCell>{parsedNoResultsText}</TableCell>
           </TableRow>
         );

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -53,6 +53,7 @@
       showError,
       autoLoadOnScroll,
       autoLoadTakeAmount,
+      noResultsText,
       dataComponentAttribute,
     } = options;
     const repeaterRef = React.createRef();
@@ -83,6 +84,7 @@
     const [interactionFilter, setInteractionFilter] = useState({});
     const perPageLabel = useText(labelRowsPerPage);
     const numOfPagesLabel = useText(labelNumberOfPages);
+    const parsedNoResultsText = useText(noResultsText);
 
     const { label: searchPropertyLabel = '{property}', kind } =
       getProperty(searchProperty) || {};
@@ -494,6 +496,14 @@
             ))}
           </TableRow>
         ));
+      }
+
+      if (results.length === 0 && parsedNoResultsText) {
+        return (
+          <TableRow classes={{ root: classes.bodyRow }}>
+            <TableCell>{parsedNoResultsText}</TableCell>
+          </TableRow>
+        );
       }
 
       return results.map((value) => (

--- a/src/prefabs/structures/DataList/options/index.ts
+++ b/src/prefabs/structures/DataList/options/index.ts
@@ -19,9 +19,14 @@ export const categories = [
     members: ['pagination', 'labelNumberOfPages', 'take', 'placeholderTake'],
   },
   {
+    label: 'Spacing',
+    expanded: false,
+    members: ['outerSpacing'],
+  },
+  {
     label: 'Messages',
     expanded: false,
-    members: ['showError', 'loadingType', 'loadingText'],
+    members: ['showError', 'loadingType', 'loadingText', 'noResultsText'],
   },
   {
     label: 'Advanced Options',
@@ -168,6 +173,9 @@ export const dataListOptions = {
         value: 'default',
       },
     },
+  }),
+  noResultsText: variable('No results text', {
+    value: [''],
   }),
 
   ...advanced('DataList'),

--- a/src/prefabs/structures/DataTable/options/index.ts
+++ b/src/prefabs/structures/DataTable/options/index.ts
@@ -65,6 +65,11 @@ export const categories = [
     members: ['outerSpacing'],
   },
   {
+    label: 'Messages',
+    expanded: false,
+    members: ['showError', 'noResultsText'],
+  },
+  {
     label: 'Advanced Options',
     expanded: false,
     members: ['dataComponentAttribute'],
@@ -305,6 +310,9 @@ export const dataTableOptions = {
         { name: 'Interaction', value: 'interaction' },
       ],
     },
+  }),
+  noResultsText: variable('No results text', {
+    value: [''],
   }),
 
   ...advanced('DataTable'),


### PR DESCRIPTION
Currently, there is no option in a Data List or Data table PB component to show a (default) message when there are no results fetched from the Data API. The only way to properly show that there are no results, is to use an “OnNoResults” interaction in combination with a Conditional component and a Text component. By adding a variable option to these two Data components, builders can save an interaction and (at least) two additional components for each Data List/Table which can help reduce the page complexity.