### PR TITLE
fix: overflow option added for allowing sticky

### DIFF
--- a/src/components/column.js
+++ b/src/components/column.js
@@ -4,7 +4,7 @@
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'VERTICAL',
   jsx: (() => {
-    const { visible, dataComponentAttribute } = options;
+    const { visible, dataComponentAttribute, overflow } = options;
     const { env, useText } = B;
     const isDev = env === 'dev';
     const isEmpty = children.length === 0;
@@ -26,6 +26,7 @@
         className={[
           classes.column,
           isVisible || isDev ? '' : classes.hide,
+          overflow && classes.overflow,
         ].join(' ')}
         data-component={useText(dataComponentAttribute) || 'Column'}
       >
@@ -125,7 +126,6 @@
         borderColor: 'transparent',
         borderStyle: 'none',
         borderRadius: 0,
-        overflow: isDev ? 'unset' : 'auto',
         boxSizing: 'border-box',
         [`@media ${mediaMinWidth(600)}`]: {
           display: ({
@@ -306,6 +306,9 @@
       },
       hide: {
         display: 'none !important',
+      },
+      overflow: {
+        overflow: isDev ? 'unset' : 'auto',
       },
     };
   },

--- a/src/prefabs/structures/Column/options/index.ts
+++ b/src/prefabs/structures/Column/options/index.ts
@@ -37,7 +37,7 @@ export const categories = [
   {
     label: 'Advanced Options',
     expanded: false,
-    members: ['dataComponentAttribute'],
+    members: ['dataComponentAttribute', 'overflow'],
   },
 ];
 
@@ -188,6 +188,9 @@ export const columnOptions = {
   }),
   innerSpacing: sizes('Inner space', {
     value: ['M', 'M', 'M', 'M'],
+  }),
+  overflow: toggle('Overflow', {
+    value: true,
   }),
 
   ...advanced('Column'),


### PR DESCRIPTION
Added an extra option to the column advanced options. When deselecting this option, it removes the CSS class 'overflow', so you can use 'display sticky' in your box, so you can have menu's that scroll with your content.