### PR TITLE
fix: no results message stretches to table width

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -501,7 +501,9 @@
       if (results.length === 0 && parsedNoResultsText) {
         return (
           <TableRow>
-            <TableCell>{parsedNoResultsText}</TableCell>
+            <TableCell colSpan={children.length}>
+              {parsedNoResultsText}
+            </TableCell>
           </TableRow>
         );
       }


### PR DESCRIPTION
Makes sure that the message takes over all columns in the data table (i.e. 100% width) when there are no results, instead of cropping the message inside the first column when there are multiple column inside the table.