### PR TITLE
Fix/tab pushes rhs treeview away page 3551

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -274,7 +274,7 @@
               style.getFontSize(font, 'Desktop'),
           },
         },
-        display: 'flex',
+        display: 'grid',
         height: ({ options: { height } }) => (isDev ? '100%' : height),
         width: ({ options: { width } }) => (isDev ? '100%' : width),
         flexDirection: ({ options: { alignment } }) => {


### PR DESCRIPTION
In [PAGE-3551](https://bettyblocks.atlassian.net/browse/PAGE-3551) the Tabs component pushes the RHS treeview away. This is because of the display format. I have changed this to "grid".

The issue "RHS treeview" is still present if the media-width is smaller than 840px, but that is not applicable to the tabs component.

