### PR TITLE
Feat/array compare option conditional

### DIFF
--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -41,14 +41,14 @@
     }
 
     const evalCondition = () => {
+      if (!initVisibility && leftValue === '' && rightValue === '') {
+        return false;
+      }
+
       const [leftParsed, rightParsed] =
         canBeNumber(leftValue) && canBeNumber(rightValue)
           ? [parseFloat(leftValue), parseFloat(rightValue)]
           : [leftValue.toString(), rightValue.toString()];
-
-      if (!initVisibility && leftValue === '' && rightValue === '') {
-        return false;
-      }
 
       switch (compare) {
         case 'neq':

--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -20,7 +20,6 @@
 
     const canBeNumber = (value) => {
       return (
-        value !== '' &&
         (typeof value === 'string' || typeof value === 'number') &&
         !isNaN(value)
       );
@@ -34,15 +33,22 @@
     const [visible, setVisible] = useState();
     const logic = useLogic(displayLogic);
 
-    const evalCondition = () => {
-      if (!initVisibility && leftValue === '' && rightValue === '') {
-        return false;
-      }
+    function isEmpty(value) {
+      return (
+        value == null ||
+        (typeof value === 'string' && value.trim().length === 0)
+      );
+    }
 
+    const evalCondition = () => {
       const [leftParsed, rightParsed] =
         canBeNumber(leftValue) && canBeNumber(rightValue)
           ? [parseFloat(leftValue), parseFloat(rightValue)]
           : [leftValue.toString(), rightValue.toString()];
+
+      if (!initVisibility && leftValue === '' && rightValue === '') {
+        return false;
+      }
 
       switch (compare) {
         case 'neq':
@@ -59,6 +65,19 @@
           return leftParsed >= rightParsed;
         case 'lteq':
           return leftParsed <= rightParsed;
+        case 'arr': {
+          const leftArr = isEmpty(leftParsed)
+            ? leftParsed
+            : leftParsed.split(',');
+          const rightArr = isEmpty(rightParsed)
+            ? rightParsed
+            : rightParsed.split(',');
+          const result =
+            isEmpty(leftArr) || isEmpty(rightArr)
+              ? null
+              : leftArr.some((i) => rightArr.includes(i));
+          return result;
+        }
         default:
           return leftParsed === rightParsed;
       }

--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -65,7 +65,7 @@
           return leftParsed >= rightParsed;
         case 'lteq':
           return leftParsed <= rightParsed;
-        case 'arr': {
+        case 'in': {
           const leftArr = isEmpty(leftParsed)
             ? leftParsed
             : leftParsed.split(',');

--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -66,17 +66,10 @@
         case 'lteq':
           return leftParsed <= rightParsed;
         case 'in': {
-          const leftArr = isEmpty(leftParsed)
-            ? leftParsed
-            : leftParsed.split(',');
-          const rightArr = isEmpty(rightParsed)
-            ? rightParsed
-            : rightParsed.split(',');
-          const result =
-            isEmpty(leftArr) || isEmpty(rightArr)
-              ? null
-              : leftArr.some((i) => rightArr.includes(i));
-          return result;
+          if (isEmpty(leftParsed) || isEmpty(rightParsed)) return false;
+          const leftArr = leftParsed.split(',') || leftParsed;
+          const rightArr = rightParsed.split(',') || rightParsed;
+          return leftArr.some((i) => rightArr.includes(i));
         }
         default:
           return leftParsed === rightParsed;

--- a/src/components/conditional.js
+++ b/src/components/conditional.js
@@ -20,6 +20,7 @@
 
     const canBeNumber = (value) => {
       return (
+        value !== '' &&
         (typeof value === 'string' || typeof value === 'number') &&
         !isNaN(value)
       );

--- a/src/prefabs/structures/Conditional/options/index.ts
+++ b/src/prefabs/structures/Conditional/options/index.ts
@@ -83,8 +83,8 @@ export const conditionalOptions = {
           value: 'lteq',
         },
         {
-          name: 'Array contains one or multiple values',
-          value: 'arr',
+          name: 'IN',
+          value: 'in',
         },
       ],
       condition: showIf('type', 'EQ', 'singleRule'),

--- a/src/prefabs/structures/Conditional/options/index.ts
+++ b/src/prefabs/structures/Conditional/options/index.ts
@@ -82,6 +82,10 @@ export const conditionalOptions = {
           name: 'Less than or equal to',
           value: 'lteq',
         },
+        {
+          name: 'Array contains one or multiple values',
+          value: 'arr',
+        },
       ],
       condition: showIf('type', 'EQ', 'singleRule'),
     },


### PR DESCRIPTION
With this option, you can compare two arrays. The Checkbox Group component for example returns a string of ID's which this options turns in to an array. So you can create your own 'array' in the right operator in the condition by typing 1,2,3 for example, which will also be turned in to an array and then compared to the other array, if there are any matches in the arrays it will return a true and the conditional will be visible.