### PR TITLE
fix: properly display error msg in data table header PFR-727

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -469,15 +469,22 @@
     };
 
     const renderTableHead = () => {
-      if ((loading && !loadOnScroll) || error) {
+      if (loading && !loadOnScroll) {
         return Array.from(Array(children.length).keys()).map((colIdx) => (
           <TableCell key={colIdx}>
-            <div className={classes.skeleton}>
-              {error && displayError && error.message}
-            </div>
+            <div className={classes.skeleton} />
           </TableCell>
         ));
       }
+
+      if (error) {
+        return (
+          <TableCell colSpan={children.length}>
+            {error && displayError && error.message}
+          </TableCell>
+        );
+      }
+
       return (
         <Children headerOnly handleSort={handleSort} orderBy={orderBy}>
           {children}


### PR DESCRIPTION
This fix makes sure the error message is entirely shown in the header of the data table component. An example of the current (before) and new (after) situation can be seen in [PFR-727](https://bettyblocks.atlassian.net/browse/PFR-727).