### PR TITLE
Fix/improve visibility delete icon in chip autocomplete pfr 737

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.165.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.164.0...v2.165.0) (2023-10-17)
+
+
+### Bug Fixes
+
+* existing var ([25b3a8d](https://github.com/bettyblocks/material-ui-component-set/commit/25b3a8d9cbe1831ab29c9e729449fcad2aeabc29))
+
+
+### Features
+
+* fix checkbox for state values ([5e9eced](https://github.com/bettyblocks/material-ui-component-set/commit/5e9eced617d3bd8d2301a59b84e86883a2ffd998))
+
 ## [2.163.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.163.0...v2.163.1) (2023-10-13)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.164.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.163.0...v2.164.0) (2023-10-16)
+
+
+### Bug Fixes
+
+* remove bench release step from release ci-cd ([69e887f](https://github.com/bettyblocks/material-ui-component-set/commit/69e887f8dfaa7b4bceb7aa3af6b2fa7c2c01336c))
+
+
+### Features
+
+* fix zindex for box component ([93499fc](https://github.com/bettyblocks/material-ui-component-set/commit/93499fcf688c4bc947926279139e021ffe6011ee))
+
 # [2.163.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.162.0...v2.163.0) (2023-10-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.163.0",
+  "version": "2.164.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.164.0",
+  "version": "2.165.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/multiAutoCompleteInput.js
+++ b/src/components/multiAutoCompleteInput.js
@@ -1055,6 +1055,13 @@
               style.getColor(backgroundColorChip),
               '!important',
             ],
+            '& .MuiSvgIcon-root': {
+              color: ({ options: { backgroundColorChip, textColorChip } }) =>
+                backgroundColorChip !== 'Light' && [
+                  style.getColor(textColorChip),
+                  '!important',
+                ],
+            },
           },
         },
         '& .MuiIconButton-root': {


### PR DESCRIPTION
When the chips in the autocomplete have a dark background color, the delete icon is not (clearly) visible. 

If the background color is dark, you will apply a light color to the text within the chip and the icon should behave the same. By default, the background color of the chip is set to Light (from the theme builder). The default Material UI color for the delete icon is fine then, but as soon as the background color of the chip is changed the icon color should be the same as the text color. This was a finding when working with the design system from the police. The UI was agreed upon with UX.