### PR TITLE
fix: improve visibility of delete icon in chips autocomplete

### DIFF
--- a/src/components/multiAutoCompleteInput.js
+++ b/src/components/multiAutoCompleteInput.js
@@ -1055,6 +1055,13 @@
               style.getColor(backgroundColorChip),
               '!important',
             ],
+            '& .MuiSvgIcon-root': {
+              color: ({ options: { backgroundColorChip, textColorChip } }) =>
+                backgroundColorChip !== 'Light' && [
+                  style.getColor(textColorChip),
+                  '!important',
+                ],
+            },
           },
         },
         '& .MuiIconButton-root': {


### PR DESCRIPTION
When the chips in the autocomplete have a dark background color, the delete icon is not (clearly) visible.

If the background color is dark, you will apply a light color to the text within the chip and the icon should behave the same. By default, the background color of the chip is set to Light (from the theme builder). The default Material UI color for the delete icon is fine then, but as soon as the background color of the chip is changed the icon color should be the same as the text color. This was a finding when working with the design system from the police. The UI was agreed upon with UX.