### PR TITLE
feat: allow to disable preload children in dialog PFR-764

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+# [2.167.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.166.0...v2.167.0) (2023-11-02)
+
+
+### Bug Fixes
+
+* use uuid for object component as value ([6f6294e](https://github.com/bettyblocks/material-ui-component-set/commit/6f6294e916d2b48096e65777ceace8a199439a6b))
+
+
+### Features
+
+* navToOutputUrl by default in questionnaire start ([83d94ae](https://github.com/bettyblocks/material-ui-component-set/commit/83d94ae2c0468be96ed108129b20cc929e96cf0d))
+
 # [2.166.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.165.1...v2.166.0) (2023-11-01)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [2.166.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.165.1...v2.166.0) (2023-11-01)
+
+
+### Features
+
+* add questionnaire page templates ([81925ad](https://github.com/bettyblocks/material-ui-component-set/commit/81925ad28c15c153aee7a2ba5f228fb263afff55))
+
 ## [2.165.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.165.0...v2.165.1) (2023-11-01)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.166.0",
+  "version": "2.167.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.165.1",
+  "version": "2.166.0",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -12,6 +12,7 @@
       runTimeVisibility,
       width,
       disableClick: disableBackdropClick,
+      preLoadChildren,
       dataComponentAttribute,
     } = options;
     const { Dialog } = window.MaterialUI.Core;
@@ -22,6 +23,7 @@
       ? isVisible
       : runTimeVisibility !== 'false';
     const [isOpen, setIsOpen] = useState(componentVisibility);
+    const [keepMounted, setKeepMounted] = useState(preLoadChildren);
 
     const closeDialog = () => setIsOpen(false);
     const openDialog = () => setIsOpen(true);
@@ -29,6 +31,10 @@
     useEffect(() => {
       setIsOpen(componentVisibility);
     }, [componentVisibility]);
+
+    useEffect(() => {
+      if (isOpen) setKeepMounted(true);
+    }, [isOpen]);
 
     useEffect(() => {
       B.defineFunction('Show', openDialog);
@@ -59,7 +65,7 @@
         fullWidth
         maxWidth={width}
         aria-labelledby="modal-dialog"
-        keepMounted
+        keepMounted={keepMounted}
         disableBackdropClick={disableBackdropClick}
         data-component={useText(dataComponentAttribute) || 'Dialog'}
       >

--- a/src/components/radioinput.js
+++ b/src/components/radioinput.js
@@ -70,7 +70,9 @@
     let resolvedCurrentValue;
 
     // set the value based on the selected property type (list, relational or object)
-    if (isListProperty || isObjectProperty) {
+    if (isObjectProperty) {
+      resolvedCurrentValue = JSON.stringify({ uuid: defaultValueText });
+    } else if (isListProperty) {
       resolvedCurrentValue = defaultValueText;
     } else if (isPropertyArray && !isObjectProperty) {
       resolvedCurrentValue = parseInt(defaultValueText, 10) || '';

--- a/src/components/selectInput.js
+++ b/src/components/selectInput.js
@@ -57,7 +57,10 @@
     } = modelProperty;
 
     const isObjectProperty = kind === 'object' || kind === 'OBJECT';
-    const resolvedCurrentValue = defaultValueText || placeholderLabelText;
+
+    const resolvedCurrentValue = isObjectProperty
+      ? JSON.stringify({ uuid: defaultValueText })
+      : defaultValueText || placeholderLabelText;
 
     const [currentValue, setCurrentValue] = useState(resolvedCurrentValue);
     B.defineFunction('Clear', () => setCurrentValue(''));

--- a/src/prefabs/pageWithQuestionnaireStart.tsx
+++ b/src/prefabs/pageWithQuestionnaireStart.tsx
@@ -19,6 +19,8 @@ import {
   PrefabComponentOption,
   wrapper,
   linked,
+  PrefabInteraction,
+  InteractionType,
 } from '@betty-blocks/component-sdk';
 import {
   Box as prefabBox,
@@ -49,6 +51,18 @@ import {
   ModelQuery,
 } from './types';
 
+const interactions: PrefabInteraction[] = [
+  {
+    type: InteractionType.Global,
+    name: 'navigateToOutputUrl',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      sourceComponentId: '#createAction',
+    },
+    parameters: [],
+  },
+];
+
 const attrs = {
   name: 'Questionnaire Startpage',
   icon: Icon.SubmitButtonIcon,
@@ -61,6 +75,7 @@ const attrs = {
   previewImage:
     'https://assets.bettyblocks.com/63b1c6ccc6874e0796e5cc5b7e41b3da_assets/files/b520d74dff324c5f8e06b319d02c4c6e',
   category: 'FORMV2',
+  interactions,
 };
 
 const beforeCreate = ({

--- a/src/prefabs/questionnaire/dropdownWidget.ts
+++ b/src/prefabs/questionnaire/dropdownWidget.ts
@@ -204,7 +204,9 @@ export const dropdownWidget = [
                     value: [''],
                     optionRef: {
                       sourceId: '#dropdownInputPropertyRef',
-                      inherit: [{ name: '$name', id: '$id', type: 'PROPERTY' }],
+                      inherit: [
+                        { id: '$id', type: 'PROPERTY', useKey: 'uuid' },
+                      ],
                     },
                   }),
                   floatLabel: toggle('Place label above input', {

--- a/src/prefabs/questionnaire/radioWidget.ts
+++ b/src/prefabs/questionnaire/radioWidget.ts
@@ -202,7 +202,11 @@ export const radioWidget = [
                       optionRef: {
                         sourceId: '#radioInputPropertyRef',
                         inherit: [
-                          { name: '$name', id: '$id', type: 'PROPERTY' },
+                          {
+                            id: '$id',
+                            type: 'PROPERTY',
+                            useKey: 'uuid',
+                          },
                         ],
                       },
                     }),

--- a/src/prefabs/radioinput.tsx
+++ b/src/prefabs/radioinput.tsx
@@ -316,7 +316,7 @@ const beforeCreate = ({
                 {
                   id: propertyId,
                   type: 'PROPERTY',
-                  name: `{{ ${model?.name}.${name} }}`,
+                  useKey: 'uuid',
                 },
               ];
 

--- a/src/prefabs/selectinput.tsx
+++ b/src/prefabs/selectinput.tsx
@@ -325,7 +325,7 @@ const beforeCreate = ({
                 {
                   id: propertyId,
                   type: 'PROPERTY',
-                  name: `{{ ${model?.name}.${name} }}`,
+                  useKey: 'uuid',
                 },
               ];
 

--- a/src/prefabs/structures/Dialog/options/advanced.ts
+++ b/src/prefabs/structures/Dialog/options/advanced.ts
@@ -1,8 +1,14 @@
-import { toggle, variable } from '@betty-blocks/component-sdk';
+import { toggle, variable, hideIf } from '@betty-blocks/component-sdk';
 
 export const advanced = {
   invisible: toggle('Invisible', {
     value: false,
+  }),
+  preLoadChildren: toggle('Preload child components', {
+    value: true,
+    configuration: {
+      condition: hideIf('runTimeVisibility', 'EQ', 'true'),
+    },
   }),
   dataComponentAttribute: variable('Test attribute', {
     value: ['Dialog'],

--- a/src/prefabs/structures/Dialog/options/index.ts
+++ b/src/prefabs/structures/Dialog/options/index.ts
@@ -5,7 +5,7 @@ export const categories = [
   {
     label: 'Advanced Options',
     expanded: false,
-    members: ['dataComponentAttribute', 'invisible'],
+    members: ['dataComponentAttribute', 'preLoadChildren', 'invisible'],
   },
 ];
 


### PR DESCRIPTION
Let’s say you have a Dialog on your page that is initially hidden. All child components inside the Dialog that request data (like a Form, Data Container, (Multi) Autocomplete, Data List or Data Table) do fire calls to the Data API despite that they are not even visible. This PR adds an option to the Dialog component to disable preloading all child components to prevent unnecessary Data API calls.

[PFR-764](https://bettyblocks.atlassian.net/browse/PFR-764)