### PR TITLE
feat: allow to disable preload children in dialog PFR-764

### DIFF
--- a/src/components/dialog.js
+++ b/src/components/dialog.js
@@ -12,6 +12,7 @@
       runTimeVisibility,
       width,
       disableClick: disableBackdropClick,
+      preLoadChildren,
       dataComponentAttribute,
     } = options;
     const { Dialog } = window.MaterialUI.Core;
@@ -22,6 +23,7 @@
       ? isVisible
       : runTimeVisibility !== 'false';
     const [isOpen, setIsOpen] = useState(componentVisibility);
+    const [keepMounted, setKeepMounted] = useState(preLoadChildren);
 
     const closeDialog = () => setIsOpen(false);
     const openDialog = () => setIsOpen(true);
@@ -29,6 +31,10 @@
     useEffect(() => {
       setIsOpen(componentVisibility);
     }, [componentVisibility]);
+
+    useEffect(() => {
+      if (isOpen) setKeepMounted(true);
+    }, [isOpen]);
 
     useEffect(() => {
       B.defineFunction('Show', openDialog);
@@ -59,7 +65,7 @@
         fullWidth
         maxWidth={width}
         aria-labelledby="modal-dialog"
-        keepMounted
+        keepMounted={keepMounted}
         disableBackdropClick={disableBackdropClick}
         data-component={useText(dataComponentAttribute) || 'Dialog'}
       >

--- a/src/prefabs/structures/Dialog/options/advanced.ts
+++ b/src/prefabs/structures/Dialog/options/advanced.ts
@@ -1,8 +1,14 @@
-import { toggle, variable } from '@betty-blocks/component-sdk';
+import { toggle, variable, hideIf } from '@betty-blocks/component-sdk';
 
 export const advanced = {
   invisible: toggle('Invisible', {
     value: false,
+  }),
+  preLoadChildren: toggle('Preload child components', {
+    value: true,
+    configuration: {
+      condition: hideIf('runTimeVisibility', 'EQ', 'true'),
+    },
   }),
   dataComponentAttribute: variable('Test attribute', {
     value: ['Dialog'],

--- a/src/prefabs/structures/Dialog/options/index.ts
+++ b/src/prefabs/structures/Dialog/options/index.ts
@@ -5,7 +5,7 @@ export const categories = [
   {
     label: 'Advanced Options',
     expanded: false,
-    members: ['dataComponentAttribute', 'invisible'],
+    members: ['dataComponentAttribute', 'preLoadChildren', 'invisible'],
   },
 ];
 


### PR DESCRIPTION
Let’s say you have a Dialog on your page that is initially hidden. All child components inside the Dialog that request data (like a Form, Data Container, (Multi) Autocomplete, Data List or Data Table) do fire calls to the Data API despite that they are not even visible. This PR adds an option to the Dialog component to disable preloading all child components to prevent unnecessary Data API calls. Once the Dialog has been opened, it should not fire the data calls again.

[PFR-764](https://bettyblocks.atlassian.net/browse/PFR-764)