### PR TITLE
fix: click and hover feedback menu component PFR-781

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -245,6 +245,9 @@
           fullWidth ? 'block' : 'inline-block',
         width: ({ options: { fullWidth } }) => fullWidth && '100%',
         minHeight: '1rem',
+        '& button': {
+          pointerEvents: 'none',
+        },
       },
       button: {
         color: ({ options: { background, disabled, textColor, variant } }) => [

--- a/src/components/menuItem.js
+++ b/src/components/menuItem.js
@@ -126,10 +126,11 @@
     const isDev = env === 'dev';
     return {
       root: {
-        backgroundColor: ({ options: { backgroundColor } }) => [
-          style.getColor(backgroundColor),
-          '!important',
-        ],
+        backgroundColor: ({ options: { backgroundColor } }) =>
+          backgroundColor !== 'Transparent' && [
+            style.getColor(backgroundColor),
+            '!important',
+          ],
         color: ({ options: { disabled, textColor } }) => [
           !disabled ? style.getColor(textColor) : 'rgba(0, 0, 0, 0.26)',
           '!important',

--- a/src/components/menuItem.js
+++ b/src/components/menuItem.js
@@ -144,6 +144,7 @@
             iconPosition === 'start' ? '0.5rem' : '',
           marginLeft: ({ options: { iconPosition } }) =>
             iconPosition === 'end' ? '0.5rem' : '',
+          color: ({ options: { iconColor } }) => style.getColor(iconColor),
         },
         ...(isDev && {
           '&:hover': {

--- a/src/prefabs/structures/MenuItem/options/index.ts
+++ b/src/prefabs/structures/MenuItem/options/index.ts
@@ -21,7 +21,7 @@ export const categories = [
   {
     label: 'Styling',
     expanded: false,
-    members: ['backgroundColor', 'textColor', 'dense', 'divider'],
+    members: ['backgroundColor', 'iconColor', 'textColor', 'dense', 'divider'],
   },
   {
     label: 'Advanced Options',
@@ -94,6 +94,10 @@ export const menuItemOptions = {
         { name: 'End', value: 'end' },
       ],
     },
+  }),
+  iconColor: color('Icon color', {
+    value: ThemeColor.PRIMARY,
+    configuration: { condition: hideIf('icon', 'EQ', 'none') },
   }),
   textColor: color('Text color', { value: ThemeColor.PRIMARY }),
   disabled: toggle('Disabled', { value: false }),


### PR DESCRIPTION
The default behavior of the MUI Menu Item component is that the background color changes on hover, but due to a CSS rule in the styles section of the component this hover feedback is not present. In design time you don’t want to see any feedback on click or on hover, but in runtime you do want to see this. This PR fixes both visual issues. Additionally, an option has been added to change the color of the icon independently of the text.

A link to the MUI Menu component: [React Menu component - Material UI](https://mui.com/material-ui/react-menu/).
A link to the PFR ticket: [PFR-781](https://bettyblocks.atlassian.net/browse/PFR-781).