### PR TITLE
fix: allow to resubmit create or update form BO

### DIFF
--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -553,7 +553,7 @@ const interactions: PrefabInteraction[] = [
   {
     type: InteractionType.Custom,
     name: 'Enable',
-    sourceEvent: 'onActionSuccess',
+    sourceEvent: 'onActionDone',
     ref: {
       targetComponentId: '#createSubmitButton',
       sourceComponentId: '#createForm',
@@ -571,7 +571,7 @@ const interactions: PrefabInteraction[] = [
   {
     type: InteractionType.Custom,
     name: 'Enable',
-    sourceEvent: 'onActionSuccess',
+    sourceEvent: 'onActionDone',
     ref: {
       targetComponentId: '#editSubmitButton',
       sourceComponentId: '#updateForm',


### PR DESCRIPTION
The back office page template comes with a create and update form. There are several interactions on these forms of which the Disable and Enable submit button are two of them. The Disable interaction is triggered on submit and the Enable interaction is triggered when the action has been submitted successfully, but when the form doesn’t submit successfully (for whatever reason, e.g. required values missing) you’re stuck and you can’t resubmit the form because the submit button stays disabled.

This PR allows you to resubmit a create or update form.
The link to the PFR ticket: [PFR-782](https://bettyblocks.atlassian.net/browse/PFR-782).