### PR TITLE
feat: add "no options text" variable option to autocompletes PFR-783

### DIFF
--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -38,6 +38,7 @@
       minvalue,
       model,
       nameAttribute: nameAttributeRaw,
+      noOptionsText: noOptionsTextRaw,
       groupBy,
       order,
       orderBy,
@@ -76,6 +77,7 @@
     const displayError = errorType === 'built-in';
     const placeholder = useText(placeholderRaw);
     const helperText = useText(helperTextRaw);
+    const noOptionsText = useText(noOptionsTextRaw);
     const nameAttribute = useText(nameAttributeRaw);
     const changeContext = useRef(null);
     const [disabled, setIsDisabled] = useState(initialDisabled);
@@ -755,6 +757,7 @@
             setInputValue('');
           }}
           options={currentOptionsGrouped || currentOptions}
+          noOptionsText={noOptionsText}
           renderInput={(params) => (
             <>
               {!isListProperty && (

--- a/src/components/multiAutoCompleteInput.js
+++ b/src/components/multiAutoCompleteInput.js
@@ -44,6 +44,7 @@
       minvalue,
       model,
       nameAttribute: nameAttributeRaw,
+      noOptionsText: noOptionsTextRaw,
       groupBy,
       optionType,
       order,
@@ -82,6 +83,7 @@
     const displayError = errorType === 'built-in';
     const placeholder = useText(placeholderRaw);
     const helperText = useText(helperTextRaw);
+    const noOptionsText = useText(noOptionsTextRaw);
     const nameAttribute = useText(nameAttributeRaw);
     const [helper, setHelper] = useState(useText(helperTextRaw));
     const [errorState, setErrorState] = useState(false);
@@ -775,6 +777,7 @@
             setInputValue('');
           }}
           options={currentOptionsGrouped || currentOptions}
+          noOptionsText={noOptionsText}
           renderInput={(params) => (
             <>
               {(optionType === 'model' || optionType === 'variable') && (

--- a/src/prefabs/structures/AutocompleteInput/options/validation.ts
+++ b/src/prefabs/structures/AutocompleteInput/options/validation.ts
@@ -18,6 +18,7 @@ export const validation = {
   disabled: toggle('Disabled', { value: false }),
   placeholder: variable('Placeholder'),
   helperText: variable('Helper text'),
+  noOptionsText: variable('No options text', { value: ['No options'] }),
   type: text('Type', {
     value: '',
     configuration: { condition: showIf('type', 'EQ', 'never') },

--- a/src/prefabs/structures/MultiAutoCompleteInput/options/validation.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/options/validation.ts
@@ -35,6 +35,7 @@ export const validation = {
   disabled: toggle('Disabled', { value: false }),
   placeholder: variable('Placeholder'),
   helperText: variable('Helper text'),
+  noOptionsText: variable('No options text', { value: ['No options'] }),
   type: text('Type', {
     value: '',
     configuration: { condition: showIf('type', 'EQ', 'never') },


### PR DESCRIPTION
The current Autocomplete component always shows the English label “No options” when there are no results and there is no way to override this. There is an option in the Material UI Autocomplete component for customizing this message: [Autocomplete API - Material UI](https://mui.com/material-ui/api/autocomplete/#Autocomplete-prop-noOptionsText). 

This change makes it possible to make the component fully multilingual or to make the label more informative like “No rooms available” or “No departments found”.

Link to the PFR ticket: [PFR-783](https://bettyblocks.atlassian.net/browse/PFR-783).