### PR TITLE
feat: add CSS rule for icon font size in avatar PFR-788

### DIFF
--- a/src/components/avatar.js
+++ b/src/components/avatar.js
@@ -68,6 +68,9 @@
         fontWeight: ({ options: { fontWeight } }) => fontWeight,
         '&.MuiAvatar-root': {
           fontSize: ({ options: { fontSize } }) => fontSize,
+          '& .MuiSvgIcon-root': {
+            fontSize: ({ options: { fontSize } }) => fontSize,
+          },
         },
       },
     };


### PR DESCRIPTION
Currently you’re only able to change the font size of the text and it’s not possible to change the font size of the icon.

A page design often includes a list of people with profile pictures, and a fallback image/icon should be used in case there is no image present. If the size of the avatar is somewhat bigger than the default, the icon size does not really match because it always stays the same size. 

This PR adds the ability to change the font size of the icon with the existing font size component option.

Link to PFR ticket: [PFR-788](https://bettyblocks.atlassian.net/browse/PFR-788).