### PR TITLE
fix: make the wait for request option work together with the loading

### DIFF
--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -241,7 +241,11 @@
                   );
                 }
 
-                if (loading && loadingType === 'showChildren') {
+                if (
+                  loading &&
+                  loadingType === 'showChildren' &&
+                  !waitForRequest
+                ) {
                   B.triggerEvent('onLoad', loading);
                   // key attribute forces a rerender after loading
                   return (


### PR DESCRIPTION
type option

This is so that even if the loading type is set to content, it respects the wait for request setting