### PR TITLE
fix: replace onActionDone trigger by onActionSuccess and onActionError

### DIFF
--- a/src/prefabs/backOffice.tsx
+++ b/src/prefabs/backOffice.tsx
@@ -553,7 +553,16 @@ const interactions: PrefabInteraction[] = [
   {
     type: InteractionType.Custom,
     name: 'Enable',
-    sourceEvent: 'onActionDone',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      targetComponentId: '#createSubmitButton',
+      sourceComponentId: '#createForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Enable',
+    sourceEvent: 'onActionError',
     ref: {
       targetComponentId: '#createSubmitButton',
       sourceComponentId: '#createForm',
@@ -571,7 +580,16 @@ const interactions: PrefabInteraction[] = [
   {
     type: InteractionType.Custom,
     name: 'Enable',
-    sourceEvent: 'onActionDone',
+    sourceEvent: 'onActionSuccess',
+    ref: {
+      targetComponentId: '#editSubmitButton',
+      sourceComponentId: '#updateForm',
+    },
+  },
+  {
+    type: InteractionType.Custom,
+    name: 'Enable',
+    sourceEvent: 'onActionError',
     ref: {
       targetComponentId: '#editSubmitButton',
       sourceComponentId: '#updateForm',


### PR DESCRIPTION
The "onActionDone" interaction trigger doesn't work so I replaced it with two interactions: "onActionSuccess" and "onActionError" to re-enable the submit button after an error has occurred.