### PR TITLE
fix: make delete icon color of Image/File Upload configurable through component option PFR-809

### DIFF
--- a/src/components/fileUploadInput.js
+++ b/src/components/fileUploadInput.js
@@ -440,14 +440,14 @@
       },
       gridDevImage: {
         extend: 'devImage',
-
         margin: 0,
         borderRadius: '0.3125rem 0.3125rem 0 0',
         width: ({ options: { imagePreviewWidth } }) => imagePreviewWidth,
         height: ({ options: { imagePreviewHeight } }) => imagePreviewHeight,
       },
       deleteIcon: {
-        color: `${t.colors.light}!important`,
+        color: ({ options: { deleteIconColor } }) =>
+          style.getColor(deleteIconColor),
       },
       uploadingImage: {
         border: 'none',

--- a/src/prefabs/imageUploadInput.tsx
+++ b/src/prefabs/imageUploadInput.tsx
@@ -332,6 +332,7 @@ const optionCategories = [
       'hideLabel',
       'labelColor',
       'helperColor',
+      'deleteIconColor',
       'errorColor',
       'showImagePreview',
       'imagePreviewWidth',

--- a/src/prefabs/structures/FileUpload/index.ts
+++ b/src/prefabs/structures/FileUpload/index.ts
@@ -17,7 +17,13 @@ const defaultCategories = [
   {
     label: 'Styling',
     expanded: false,
-    members: ['hideLabel', 'labelColor', 'helperColor', 'errorColor'],
+    members: [
+      'hideLabel',
+      'labelColor',
+      'helperColor',
+      'deleteIconColor',
+      'errorColor',
+    ],
   },
   {
     label: 'Advanced settings',

--- a/src/prefabs/structures/FileUpload/options/styles.ts
+++ b/src/prefabs/structures/FileUpload/options/styles.ts
@@ -26,6 +26,9 @@ export const styles = {
   helperColor: color('Helper color', {
     value: ThemeColor.ACCENT_2,
   }),
+  deleteIconColor: color('Delete icon color', {
+    value: ThemeColor.LIGHT,
+  }),
   errorColor: color('Error color', {
     value: ThemeColor.DANGER,
   }),


### PR DESCRIPTION
When you have an Image Upload or File Upload component on a page where Light is used as background color, the delete icon for removing the uploaded image or file is not visible because it uses the same theme color.

The color of the delete icon should be configurable via a component option instead of always taking the Light color from the theme builder.

Link to the PFR ticket: [PFR-809](https://bettyblocks.atlassian.net/browse/PFR-809).