### PR TITLE
feat: select public file as background image box component PFR-680

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [2.187.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.187.2...v2.187.3) (2024-05-14)
+
+
+### Bug Fixes
+
+* comments removed ([953e815](https://github.com/bettyblocks/material-ui-component-set/commit/953e81556d0451821cceefba1a1362a3e9a7f576))
+* implementation of TECHSUP-9010 ([a445760](https://github.com/bettyblocks/material-ui-component-set/commit/a445760909c07cce563214b98646e8887ccc1381))
+
 ## [2.187.2](https://github.com/bettyblocks/material-ui-component-set/compare/v2.187.1...v2.187.2) (2024-05-06)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.187.4](https://github.com/bettyblocks/material-ui-component-set/compare/v2.187.3...v2.187.4) (2024-06-19)
+
+
+### Bug Fixes
+
+* trigger onSuccess event after file reference is successfully stored ([b3a877d](https://github.com/bettyblocks/material-ui-component-set/commit/b3a877d07a3e2d348b1e7017352826dd17080750))
+
 ## [2.187.3](https://github.com/bettyblocks/material-ui-component-set/compare/v2.187.2...v2.187.3) (2024-05-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.187.3",
+  "version": "2.187.4",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.187.2",
+  "version": "2.187.3",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/box.js
+++ b/src/components/box.js
@@ -4,11 +4,13 @@
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',
   jsx: (() => {
-    const { env, useText, useLogic } = B;
+    const { env, useText, useLogic, usePublicFile } = B;
     const { Box } = window.MaterialUI.Core;
     const {
       alignment,
       backgroundColor,
+      backgroundType,
+      backgroundImage: backgroundImageInput,
       backgroundUrl: backgroundURLInput,
       borderColor,
       contentDirection,
@@ -21,27 +23,31 @@
     const isDev = env === 'dev';
     const hasBackgroundColor = backgroundColor !== 'Transparent';
     const hasBorderColor = borderColor !== 'Transparent';
+    const { url: backgroundImageURL = '' } =
+      usePublicFile(backgroundImageInput) || {};
     const backgroundURL = useText(backgroundURLInput);
-    const [interactionBackground, setInteractionBackground] = useState('');
-    const backgroundImage = interactionBackground || backgroundURL || null;
+    const background =
+      backgroundType === 'img' ? backgroundImageURL : backgroundURL;
+    const [backgroundImage, setBackgroundImage] = useState(background);
     const isEmpty = isDev && children.length === 0;
     const isPristine =
-      isEmpty &&
-      !hasBackgroundColor &&
-      !hasBorderColor &&
-      backgroundImage === null;
+      isEmpty && !hasBackgroundColor && !hasBorderColor && !backgroundImage;
     const isFlex = alignment !== 'none' || valignment !== 'none';
     const opac = transparent ? 0 : 1;
     const [opacity, setOpacity] = useState(opac);
     const logic = useLogic(displayLogic);
 
     useEffect(() => {
+      setBackgroundImage(background);
+    }, [background]);
+
+    useEffect(() => {
       B.defineFunction('setCustomBackgroundImage', (url) => {
-        setInteractionBackground(url);
+        setBackgroundImage(url);
       });
 
       B.defineFunction('removeCustomBackgroundImage', () => {
-        setInteractionBackground('');
+        setBackgroundImage('');
       });
     }, []);
 
@@ -82,7 +88,7 @@
         onMouseLeave={handleMouseLeave}
         style={{
           ...(backgroundImage !== null && {
-            backgroundImage: `url("${backgroundURL}")`,
+            backgroundImage: `url("${backgroundImage}")`,
           }),
           opacity,
         }}

--- a/src/prefabs/structures/Box/options/index.ts
+++ b/src/prefabs/structures/Box/options/index.ts
@@ -11,6 +11,7 @@ import {
   dropdown,
   displayLogic,
   hideIf,
+  showIf,
 } from '@betty-blocks/component-sdk';
 import { advanced } from '../../advanced';
 
@@ -36,6 +37,8 @@ export const categories = [
     members: [
       'backgroundColor',
       'backgroundColorAlpha',
+      'backgroundType',
+      'backgroundImage',
       'backgroundUrl',
       'backgroundSize',
       'backgroundPosition',
@@ -186,8 +189,32 @@ export const boxOptions = {
     label: 'Background color opacity',
     value: 100,
   }),
+  backgroundType: option('CUSTOM', {
+    label: 'Background type',
+    value: 'img',
+    configuration: {
+      as: 'BUTTONGROUP',
+      dataType: 'string',
+      allowedInput: [
+        { name: 'Image', value: 'img' },
+        { name: 'Data/URL', value: 'url' },
+      ],
+    },
+  }),
+  backgroundImage: option('PUBLIC_FILE', {
+    label: 'Background image',
+    value: '',
+    configuration: {
+      mediaType: 'IMAGE',
+      allowedExtensions: ['image/*'],
+      condition: showIf('backgroundType', 'EQ', 'img'),
+    },
+  }),
   backgroundUrl: variable('Background url', {
     value: [''],
+    configuration: {
+      condition: showIf('backgroundType', 'EQ', 'url'),
+    },
   }),
   backgroundSize: buttongroup(
     'Background size',


### PR DESCRIPTION
This feature adds a new component option for selecting a public file as background image so that the image URL is always the one of the current environment, see [PFR-680](https://bettyblocks.atlassian.net/browse/PFR-680) for a more detailed explanation.