### PR TITLE
fix: show active tab indicator on page load TECHSUP-8534

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -48,7 +48,6 @@
     }, [isDev, currentTab]);
 
     useEffect(() => {
-      // Manually trigger updateIndicator() to show active tab on page load (TECHSUP-8534)
       setTimeout(() => {
         tabsRef.current.updateIndicator();
       }, 100);

--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -24,6 +24,7 @@
     const orientation =
       alignment === 'top' || alignment === 'bottom' ? 'horizontal' : 'vertical';
     const isDev = env === 'dev';
+    const tabsRef = useRef();
     const currentTab = isDev ? selectedDesignTabIndex : defaultValue;
     const [value, setValue] = useState(parseInt(currentTab - 1, 10) || 0);
     const [tabData, setTabData] = useState({});
@@ -46,6 +47,13 @@
       }
     }, [isDev, currentTab]);
 
+    useEffect(() => {
+      // Manually trigger updateIndicator() to show active tab on page load (TECHSUP-8534)
+      setTimeout(() => {
+        tabsRef.current.updateIndicator();
+      }, 100);
+    }, []);
+
     B.defineFunction('Next tab', () => {
       if (value + 1 >= children.length) return;
       setValue(value + 1);
@@ -58,6 +66,7 @@
 
     const TabsHeader = (
       <Tabs
+        action={tabsRef}
         aria-label="tabs"
         onChange={handleChange}
         value={value}


### PR DESCRIPTION
This fix makes sure the active tab indicator is shown on page load. For more information, see [TECHSUP-8534](https://bettyblocks.atlassian.net/browse/TECHSUP-8534) or the thread in [my previous PR to edge](https://github.com/bettyblocks/material-ui-component-set/pull/3426).