### PR TITLE
feat: select public file as background image box component PFR-680

### DIFF
--- a/src/components/box.js
+++ b/src/components/box.js
@@ -4,11 +4,13 @@
   allowedTypes: ['BODY_COMPONENT', 'CONTAINER_COMPONENT', 'CONTENT_COMPONENT'],
   orientation: 'HORIZONTAL',
   jsx: (() => {
-    const { env, useText, useLogic } = B;
+    const { env, useText, useLogic, usePublicFile } = B;
     const { Box } = window.MaterialUI.Core;
     const {
       alignment,
       backgroundColor,
+      backgroundType,
+      backgroundImage: backgroundImageInput,
       backgroundUrl: backgroundURLInput,
       borderColor,
       contentDirection,
@@ -21,27 +23,31 @@
     const isDev = env === 'dev';
     const hasBackgroundColor = backgroundColor !== 'Transparent';
     const hasBorderColor = borderColor !== 'Transparent';
+    const { url: backgroundImageURL = '' } =
+      usePublicFile(backgroundImageInput) || {};
     const backgroundURL = useText(backgroundURLInput);
-    const [interactionBackground, setInteractionBackground] = useState('');
-    const backgroundImage = interactionBackground || backgroundURL || null;
+    const background =
+      backgroundType === 'img' ? backgroundImageURL : backgroundURL;
+    const [backgroundImage, setBackgroundImage] = useState(background);
     const isEmpty = isDev && children.length === 0;
     const isPristine =
-      isEmpty &&
-      !hasBackgroundColor &&
-      !hasBorderColor &&
-      backgroundImage === null;
+      isEmpty && !hasBackgroundColor && !hasBorderColor && !backgroundImage;
     const isFlex = alignment !== 'none' || valignment !== 'none';
     const opac = transparent ? 0 : 1;
     const [opacity, setOpacity] = useState(opac);
     const logic = useLogic(displayLogic);
 
     useEffect(() => {
+      setBackgroundImage(background);
+    }, [background]);
+
+    useEffect(() => {
       B.defineFunction('setCustomBackgroundImage', (url) => {
-        setInteractionBackground(url);
+        setBackgroundImage(url);
       });
 
       B.defineFunction('removeCustomBackgroundImage', () => {
-        setInteractionBackground('');
+        setBackgroundImage('');
       });
     }, []);
 
@@ -82,7 +88,7 @@
         onMouseLeave={handleMouseLeave}
         style={{
           ...(backgroundImage !== null && {
-            backgroundImage: `url("${backgroundURL}")`,
+            backgroundImage: `url("${backgroundImage}")`,
           }),
           opacity,
         }}

--- a/src/prefabs/structures/Box/options/index.ts
+++ b/src/prefabs/structures/Box/options/index.ts
@@ -11,6 +11,7 @@ import {
   dropdown,
   displayLogic,
   hideIf,
+  showIf,
 } from '@betty-blocks/component-sdk';
 import { advanced } from '../../advanced';
 
@@ -36,6 +37,8 @@ export const categories = [
     members: [
       'backgroundColor',
       'backgroundColorAlpha',
+      'backgroundType',
+      'backgroundImage',
       'backgroundUrl',
       'backgroundSize',
       'backgroundPosition',
@@ -186,8 +189,32 @@ export const boxOptions = {
     label: 'Background color opacity',
     value: 100,
   }),
+  backgroundType: option('CUSTOM', {
+    label: 'Background type',
+    value: 'img',
+    configuration: {
+      as: 'BUTTONGROUP',
+      dataType: 'string',
+      allowedInput: [
+        { name: 'Image', value: 'img' },
+        { name: 'Data/URL', value: 'url' },
+      ],
+    },
+  }),
+  backgroundImage: option('PUBLIC_FILE', {
+    label: 'Background image',
+    value: '',
+    configuration: {
+      mediaType: 'IMAGE',
+      allowedExtensions: ['image/*'],
+      condition: showIf('backgroundType', 'EQ', 'img'),
+    },
+  }),
   backgroundUrl: variable('Background url', {
     value: [''],
+    configuration: {
+      condition: showIf('backgroundType', 'EQ', 'url'),
+    },
   }),
   backgroundSize: buttongroup(
     'Background size',


### PR DESCRIPTION
This feature adds a new component option for selecting a public file as background image so that the image URL is always the one of the current environment, see [PFR-680](https://bettyblocks.atlassian.net/browse/PFR-680) for a more detailed explanation.

It also fixes the existing component interactions ("setCustomBackgroundImage" and "removeCustomBackgroundImage") that were not working anymore.