### PR TITLE
feat: month picker component PFR-643

### DIFF
--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -19,6 +19,7 @@
       dateFormat,
       timeFormat,
       datetimeFormat,
+      monthFormat,
       size,
       fullWidth,
       required,
@@ -204,6 +205,19 @@
             break;
           }
 
+          case 'month': {
+            const formattedDate = DateFns.parse(parsedValue, monthFormat);
+
+            if (isValidDate(formattedDate)) {
+              setSelectedDate(formattedDate);
+            } else {
+              // convert to slashes because it conflicts with the MUI DateTimeCmp
+              const parsedValueWithSlashes = parsedValue.replace(/-/g, '/');
+              setSelectedDate(new Date(parsedValueWithSlashes));
+            }
+            break;
+          }
+
           default:
         }
       } else {
@@ -221,11 +235,13 @@
     let use24HourClock = true;
     let minDate;
     let maxDate;
+    let views;
 
     switch (type) {
       case 'date': {
         DateTimeComponent = KeyboardDatePicker;
         format = dateFormat || 'dd/MM/yyyy';
+        views = ['year', 'date'];
 
         minDate = convertToValidDate(minValueText);
         maxDate = convertToValidDate(maxValueText);
@@ -239,6 +255,7 @@
         DateTimeComponent = KeyboardDateTimePicker;
         format = datetimeFormat || 'dd/MM/yyyy HH:mm:ss';
         use24HourClock = use24HourClockTime;
+        views = ['year', 'date', 'hours', 'minutes'];
 
         resultString = isValidDate(selectedDate)
           ? selectedDate.toISOString()
@@ -249,9 +266,20 @@
         DateTimeComponent = KeyboardTimePicker;
         format = timeFormat || 'HH:mm:ss';
         use24HourClock = use24HourClockTime;
+        views = ['hours', 'minutes'];
 
         resultString = isValidDate(selectedDate)
           ? DateFns.format(selectedDate, 'HH:mm:ss')
+          : null;
+        break;
+      }
+      case 'month': {
+        DateTimeComponent = KeyboardDatePicker;
+        format = monthFormat || 'MMMM';
+        views = ['month'];
+
+        resultString = isValidDate(selectedDate)
+          ? DateFns.format(selectedDate, 'yyyy-MM')
           : null;
         break;
       }
@@ -299,6 +327,7 @@
         required={required}
         disabled={isDisabled}
         label={!hideLabel && labelText}
+        views={views}
         margin={margin}
         helperText={helper}
         disableToolbar={disableToolbar}

--- a/src/prefabs/monthPickerInput.tsx
+++ b/src/prefabs/monthPickerInput.tsx
@@ -1,0 +1,335 @@
+import * as React from 'react';
+import {
+  BeforeCreateArgs,
+  Icon,
+  prefab as makePrefab,
+  PrefabComponentOption,
+} from '@betty-blocks/component-sdk';
+import { DateTimePicker } from './structures/DateTimePicker';
+
+const beforeCreate = ({
+  close,
+  components: {
+    Content,
+    Field,
+    Footer,
+    Header,
+    FormField,
+    Toggle,
+    PropertySelector,
+    Label,
+    TextInput: Text,
+    CircleQuestion,
+    BBTooltip,
+  },
+  prefab: originalPrefab,
+  save,
+  helpers,
+}: BeforeCreateArgs) => {
+  const {
+    BettyPrefabs,
+    prepareInput,
+    useModelIdSelector,
+    useActionIdSelector,
+    usePrefabSelector,
+    usePropertyQuery,
+    setOption,
+    createUuid,
+    useModelQuery,
+    createBlacklist,
+    useModelRelationQuery,
+  } = helpers;
+
+  const [propertyPath, setProperty] = React.useState<any>('');
+  const [variableInput, setVariableInput] = React.useState(null);
+  const modelId = useModelIdSelector();
+  const actionId = useActionIdSelector();
+  const selectedPrefab = usePrefabSelector();
+  const [model, setModel] = React.useState<any>(null);
+  const [propertyBased, setPropertyBased] = React.useState(!!modelId);
+  const [prefabSaved, setPrefabSaved] = React.useState(false);
+
+  const [validationMessage, setValidationMessage] = React.useState('');
+
+  const modelRequest = useModelQuery({
+    variables: { id: modelId },
+    onCompleted: (result) => {
+      setModel(result.model);
+    },
+  });
+
+  const validate = () => {
+    if (modelRequest.loading) {
+      setValidationMessage(
+        'Model details are still loading, please try submitting again.',
+      );
+      return false;
+    }
+
+    return true;
+  };
+
+  let name: string | undefined;
+  let propertyKind;
+  let propertyModelId;
+  const componentId = createUuid();
+
+  function isProperty(path: string) {
+    return (
+      typeof path !== 'string' &&
+      typeof path === 'object' &&
+      !Array.isArray(path)
+    );
+  }
+
+  let propertyId: string;
+  if (isProperty(propertyPath)) {
+    const { id } = propertyPath;
+    propertyId = Array.isArray(id) ? id[id.length - 1] : id;
+  } else {
+    propertyId = propertyPath;
+  }
+
+  const propertyResponse = usePropertyQuery(propertyId);
+
+  if (!(propertyResponse.loading || propertyResponse.error)) {
+    if (propertyResponse.data) {
+      name = propertyResponse.data.property.label;
+      propertyKind = propertyResponse.data.property.kind;
+      propertyModelId = propertyResponse.data.property.referenceModel?.id;
+    }
+  }
+
+  const modelRelationResponse = useModelRelationQuery(propertyModelId);
+
+  let relationalProperties;
+  let modelProperty;
+  if (!(modelRelationResponse.loading || modelRelationResponse.error)) {
+    if (modelRelationResponse.data) {
+      relationalProperties = modelRelationResponse.data.model.properties;
+      modelProperty = relationalProperties.find(
+        (property) => property.name === 'id',
+      );
+    }
+  }
+
+  const unsupportedKinds = createBlacklist(['DATE']);
+
+  const structure = originalPrefab.structure[0];
+
+  if (structure.type !== 'COMPONENT')
+    return <div>expected component prefab, found {structure.type}</div>;
+
+  const handlePropertyChange = (propertyOrId): void => {
+    setProperty(propertyOrId);
+  };
+
+  if (!actionId && !prefabSaved) {
+    setPrefabSaved(true);
+    save(originalPrefab);
+  }
+
+  const actionVariableOptionType = structure.options.find(
+    (option: { type: string }) => option.type === 'ACTION_JS_VARIABLE',
+  );
+
+  const actionVariableOption = actionVariableOptionType?.key || null;
+  const labelOptionKey = 'label';
+  const nameOptionKey = 'actionVariableId';
+
+  return (
+    <>
+      <Header onClose={close} title="Configure form input field" />
+      <Content>
+        {modelId && (
+          <Field label="Property based input">
+            <FormField onClick={(): void => setPropertyBased(!propertyBased)}>
+              <Toggle
+                color="purple"
+                checked={propertyBased}
+                onChange={(): void => {}}
+              />
+            </FormField>
+          </Field>
+        )}
+        {propertyBased ? (
+          <Field
+            label="Property"
+            error={
+              validationMessage && (
+                <Text color="#e82600">{validationMessage}</Text>
+              )
+            }
+          >
+            <PropertySelector
+              allowRelations
+              disabledNames={['created_at', 'updated_at']}
+              disabledKinds={unsupportedKinds}
+              showFormat={false}
+              size="large"
+              onChange={handlePropertyChange}
+              value={propertyPath}
+              modelId={modelId}
+            />
+          </Field>
+        ) : (
+          <Field>
+            <Label>
+              Action input variable
+              <CircleQuestion
+                color="grey500"
+                size="medium"
+                data-tip="You can use this action input variable in the action itself."
+                data-for="variable-tooltip"
+              />
+            </Label>
+            <BBTooltip
+              id="variable-tooltip"
+              place="top"
+              type="dark"
+              effect="solid"
+            />
+            <Text
+              onChange={(e): void => setVariableInput(e.target.value)}
+              color="orange"
+            />
+          </Field>
+        )}
+      </Content>
+      <Footer
+        onClose={close}
+        canSave={(propertyPath && !!name) || variableInput}
+        onSave={async (): Promise<void> => {
+          // eslint-disable-next-line no-param-reassign
+          structure.id = componentId;
+
+          const kind = propertyKind || 'STRING';
+          const variableName = variableInput || name;
+          const result = await prepareInput(
+            actionId,
+            variableName,
+            kind,
+            propertyKind,
+            propertyResponse?.data?.property,
+          );
+
+          const newPrefab = { ...originalPrefab };
+          if (newPrefab.structure[0].type !== 'COMPONENT') {
+            throw new Error('expected Component');
+          }
+
+          setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
+            ...option,
+            value: variableName,
+            configuration: {
+              condition: {
+                type: 'SHOW',
+                option: 'property',
+                comparator: 'EQ',
+                value: '',
+              },
+            },
+          }));
+
+          setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
+            ...option,
+            value: [variableName],
+          }));
+
+          setOption(newPrefab.structure[0], nameOptionKey, (option) => ({
+            ...option,
+            value: result.variable.variableId,
+          }));
+
+          if (propertyBased) {
+            setOption(
+              newPrefab.structure[0],
+              'property',
+              (originalOption: PrefabComponentOption) => ({
+                ...originalOption,
+                value: {
+                  id:
+                    result.isRelational && !result.isMultiRelational
+                      ? [propertyId, modelProperty.id]
+                      : propertyId,
+                  type: 'PROPERTY',
+                  name:
+                    result.isRelational && !result.isMultiRelational
+                      ? `{{ ${model?.name}.${name}.id }}`
+                      : `{{ ${model?.name}.${name} }}`,
+                },
+              }),
+            );
+            setOption(
+              newPrefab.structure[0],
+              'label',
+              (originalOption: any) => ({
+                ...originalOption,
+                value: [
+                  {
+                    id:
+                      result.isRelational && !result.isMultiRelational
+                        ? [propertyId, modelProperty.id]
+                        : propertyId,
+                    type: 'PROPERTY_LABEL',
+                    name:
+                      result.isRelational && !result.isMultiRelational
+                        ? `{{ ${model?.name}.${name}.id }}`
+                        : `{{ ${model?.name}.${name} }}`,
+                  },
+                ],
+              }),
+            );
+          }
+          if (validate()) {
+            if (
+              (selectedPrefab?.name === BettyPrefabs.UPDATE_FORM ||
+                selectedPrefab?.name === BettyPrefabs.CREATE_FORM ||
+                selectedPrefab?.name === BettyPrefabs.FORM ||
+                selectedPrefab?.name === BettyPrefabs.LOGIN_FORM) &&
+              propertyId
+            ) {
+              const valueOptions = [
+                {
+                  id:
+                    result.isRelational && !result.isMultiRelational
+                      ? [propertyId, modelProperty.id]
+                      : propertyId,
+                  type: 'PROPERTY',
+                  name:
+                    result.isRelational && !result.isMultiRelational
+                      ? `{{ ${model?.name}.${name}.id }}`
+                      : `{{ ${model?.name}.${name} }}`,
+                },
+              ];
+
+              setOption(newPrefab.structure[0], 'value', (option) => ({
+                ...option,
+                value:
+                  option.type === 'VARIABLE'
+                    ? valueOptions
+                    : (propertyId as any),
+              }));
+            }
+          }
+          save({ ...originalPrefab, structure: [newPrefab.structure[0]] });
+        }}
+      />
+    </>
+  );
+};
+
+const attributes = {
+  category: 'FORM',
+  icon: Icon.DatePickerIcon,
+  keywords: ['Form', 'input'],
+};
+
+export default makePrefab('Month Picker', attributes, beforeCreate, [
+  DateTimePicker({
+    label: 'Month picker',
+    inputLabel: 'Month',
+    dataComponentAttribute: 'Month Input',
+    inputType: 'month',
+  }),
+]);

--- a/src/prefabs/monthPickerInput.tsx
+++ b/src/prefabs/monthPickerInput.tsx
@@ -113,7 +113,7 @@ const beforeCreate = ({
     }
   }
 
-  const unsupportedKinds = createBlacklist(['DATE']);
+  const unsupportedKinds = createBlacklist(['DATE', 'TEXT', 'STRING']);
 
   const structure = originalPrefab.structure[0];
 
@@ -257,6 +257,9 @@ const beforeCreate = ({
                     result.isRelational && !result.isMultiRelational
                       ? `{{ ${model?.name}.${name}.id }}`
                       : `{{ ${model?.name}.${name} }}`,
+                },
+                configuration: {
+                  allowedKinds: ['DATE', 'TEXT', 'STRING'],
                 },
               }),
             );

--- a/src/prefabs/structures/DateTimePicker/index.ts
+++ b/src/prefabs/structures/DateTimePicker/index.ts
@@ -7,6 +7,7 @@ export enum DateInputTypes {
   DATE_TIME = 'datetime',
   DATE = 'date',
   TIME = 'time',
+  MONTH = 'month',
 }
 
 export const DateTimePicker = (
@@ -67,6 +68,9 @@ export const DateTimePicker = (
         break;
       case DateInputTypes.TIME:
         format = 'HH:mm:ss';
+        break;
+      case DateInputTypes.MONTH:
+        format = 'MMMM';
         break;
       default:
         format = '';

--- a/src/prefabs/structures/DateTimePicker/options/index.ts
+++ b/src/prefabs/structures/DateTimePicker/options/index.ts
@@ -74,7 +74,13 @@ export const options = {
       condition: showIf('type', 'EQ', 'datetime'),
     },
   }),
-
+  monthFormat: text('Format', {
+    value: 'MMMM',
+    configuration: {
+      placeholder: 'MMMM',
+      condition: showIf('type', 'EQ', 'month'),
+    },
+  }),
   locale: buttongroup(
     'Locale',
     [


### PR DESCRIPTION
A new prefab called **Month picker** which is based on the Date picker component and meant for a user to select an available Month only. Material UI offers the [“views” prop](https://mui.com/x/react-date-pickers/date-picker/#views) that makes it easy to configure the selection views in the pop up (which is one of “date”, “year”, “month”, “day” “hours”, “minutes”, “seconds” depending on the type of the picker).

In this PR the "views" array is provided for each prefab type so that it can easily be (re)configured in the future. For example, you currently can’t select the seconds by default with the Time picker because it is not included in the views array by default, but the seconds will be shown in the input because of the default format option value “HH:mm:ss“. You could either remove ":ss" from the default value of the format option or append "seconds" to the array of views to fix this in the future.

Link to the PFR ticket: [PFR-643](https://bettyblocks.atlassian.net/browse/PFR-643).