### PR TITLE
Fix/remove jwt cookie page 4619

### DIFF
--- a/src/interactions/login.ts
+++ b/src/interactions/login.ts
@@ -34,7 +34,7 @@ function login({
 
     const d = new Date(0);
     const e = d.toUTCString();
-    document.cookie = `betty_jwt=none; expires=${e}; SameSite=Lax`;
+    document.cookie = `betty_jwt=none; expires=${e}; SameSite=Lax; path=/`;
 
     localStorage.setItem('TOKEN', jwtToken);
     localStorage.setItem('REFRESH_TOKEN', refreshToken);


### PR DESCRIPTION
After logging in via username/password, or custom-login, the betty-jwt cookie needs to always be deleted.
If the cookie was set via a page with an extra path in its url, the login-function wouldn't delete it, and the user would need to login twice.

By explicitly setting the path when deleting the cookie, the cookie is always deleted thus solving the bug.
