### PR TITLE
fix: rerender components when initial value changes

### DIFF
--- a/src/components/checkboxinput.js
+++ b/src/components/checkboxinput.js
@@ -43,6 +43,10 @@
     const helperTextResolved = useText(helperText);
     const validationValueMissingText = useText(validationValueMissing);
 
+    useEffect(() => {
+      setChecked(boolify(resolvedValue));
+    }, [resolvedValue]);
+
     const {
       Checkbox: MUICheckbox,
       Switch,

--- a/src/components/fileUploadInput.js
+++ b/src/components/fileUploadInput.js
@@ -80,6 +80,10 @@
       errorHelpers || (!hideDefaultError ? validationMessage : '') || helper;
 
     useEffect(() => {
+      setValue(initialValue);
+    }, [initialValue]);
+
+    useEffect(() => {
       firstRender.current = false;
     }, []);
 

--- a/src/components/textinput.js
+++ b/src/components/textinput.js
@@ -63,7 +63,8 @@
     const [errorState, setErrorState] = useState(error);
     const [afterFirstInvalidation, setAfterFirstInvalidation] = useState(false);
     const [helper, setHelper] = useState(useText(helperText));
-    const [currentValue, setCurrentValue] = usePageState(useText(value));
+    const optionValue = useText(value);
+    const [currentValue, setCurrentValue] = usePageState(optionValue);
     const parsedLabel = useText(label);
     const labelText = parsedLabel;
     const debouncedOnChangeRef = useRef(null);
@@ -86,6 +87,10 @@
     const placeholderText = useText(placeholder);
     const helperTextResolved = useText(helperText);
     const dataComponentAttributeValue = useText(dataComponentAttribute);
+
+    useEffect(() => {
+      setCurrentValue(optionValue);
+    }, [optionValue]);
 
     const validationMessage = (validityObject) => {
       if (validityObject.customError && patternMismatchMessage) {


### PR DESCRIPTION
+ When a datatable or a datalist triggers the refetch interaction, some components do not update their value. This fix will ensure that the state will be update with the new value