### PR TITLE
Fix/box with bg image not showing page 4710

### DIFF
--- a/src/prefabs/pageWithErrors.tsx
+++ b/src/prefabs/pageWithErrors.tsx
@@ -316,6 +316,14 @@ const beforeCreate = ({
       );
       setOption(
         backgroundBox,
+        'backgroundType',
+        (opt: PrefabComponentOption) => ({
+          ...opt,
+          value: 'url',
+        }),
+      );
+      setOption(
+        backgroundBox,
         'backgroundUrl',
         (opt: PrefabComponentOption) => ({
           ...opt,

--- a/src/prefabs/pageWithHomepageLayout.tsx
+++ b/src/prefabs/pageWithHomepageLayout.tsx
@@ -659,6 +659,18 @@ export default makePrefab('Homepage, inspirational', attrs, beforeCreate, [
                             'https://assets.bettyblocks.com/63b1c6ccc6874e0796e5cc5b7e41b3da_assets/files/Homepage_banner_gradient',
                           ],
                         }),
+                        backgroundType: option('CUSTOM', {
+                          label: 'Background type',
+                          value: 'url',
+                          configuration: {
+                            as: 'BUTTONGROUP',
+                            dataType: 'string',
+                            allowedInput: [
+                              { name: 'Image', value: 'img' },
+                              { name: 'Data/URL', value: 'url' },
+                            ],
+                          },
+                        }),
                       },
                     },
                     [

--- a/src/prefabs/pageWithLoginAndRegisterForm.tsx
+++ b/src/prefabs/pageWithLoginAndRegisterForm.tsx
@@ -976,6 +976,18 @@ export default makePrefab(
                                   },
                                 },
                               ),
+                              backgroundType: option('CUSTOM', {
+                                label: 'Background type',
+                                value: 'url',
+                                configuration: {
+                                  as: 'BUTTONGROUP',
+                                  dataType: 'string',
+                                  allowedInput: [
+                                    { name: 'Image', value: 'img' },
+                                    { name: 'Data/URL', value: 'url' },
+                                  ],
+                                },
+                              }),
                               backgroundUrl: variable('Background url', {
                                 value: [
                                   'https://assets.bettyblocks.com/7730f33d3a624ec6b5383b5dc26c79d6_assets/files/login-background.jpeg',

--- a/src/prefabs/pageWithLoginForm.tsx
+++ b/src/prefabs/pageWithLoginForm.tsx
@@ -294,6 +294,18 @@ const prefabStructure: PrefabComponent[] = [
                           backgroundOptions: toggle('Show background options', {
                             value: true,
                           }),
+                          backgroundType: option('CUSTOM', {
+                            label: 'Background type',
+                            value: 'url',
+                            configuration: {
+                              as: 'BUTTONGROUP',
+                              dataType: 'string',
+                              allowedInput: [
+                                { name: 'Image', value: 'img' },
+                                { name: 'Data/URL', value: 'url' },
+                              ],
+                            },
+                          }),
                           backgroundUrl: variable('Background url', {
                             value: [
                               'https://assets.bettyblocks.com/1e9019bb1c5c4af2ba799c2ee1761af0_assets/files/login-background',

--- a/src/prefabs/pageWithRegisterForm.tsx
+++ b/src/prefabs/pageWithRegisterForm.tsx
@@ -662,6 +662,18 @@ export default makePrefab('User, account register only', attrs, beforeCreate, [
                               as: 'UNIT',
                             },
                           }),
+                          backgroundType: option('CUSTOM', {
+                            label: 'Background type',
+                            value: 'url',
+                            configuration: {
+                              as: 'BUTTONGROUP',
+                              dataType: 'string',
+                              allowedInput: [
+                                { name: 'Image', value: 'img' },
+                                { name: 'Data/URL', value: 'url' },
+                              ],
+                            },
+                          }),
                           backgroundOptions: toggle('Show background options', {
                             value: true,
                           }),


### PR DESCRIPTION
For page-prefabs.

The backgroundType default is set to 'img', but is needed to be 'url' since it points to assets.