### PR TITLE
fix: add default value to current filter and show remaining records

### DIFF
--- a/src/prefabs/autocompleteInput.tsx
+++ b/src/prefabs/autocompleteInput.tsx
@@ -336,7 +336,7 @@ const attributes = {
   keywords: ['Form', 'input'],
 };
 
-export default prefab('Autocomplete', attributes, beforeCreate, [
+export default prefab('AutocompleteInput', attributes, beforeCreate, [
   AutocompleteInput({
     label: 'Autocomplete',
     inputLabel: 'Autocomplete',


### PR DESCRIPTION
The autocomplete component should now show its default value and other records from its filter:

![image](https://github.com/user-attachments/assets/6e63ff8c-86d2-40d2-96e0-3d4849ae275e)

And when searching it searches through all records or records within it's filter:

![image](https://github.com/user-attachments/assets/c4f603a9-c072-49df-84e1-abe11c18badd)
