### PR TITLE
feat: set focus to text input component PFR-899

### DIFF
--- a/src/components/textinput.js
+++ b/src/components/textinput.js
@@ -209,7 +209,7 @@
     const focusHandler = () =>
       setTimeout(() => {
         inputRef.current.focus();
-      }, 50);
+      }, 0);
 
     B.defineFunction('Clear', () => setCurrentValue(''));
     B.defineFunction('Enable', () => setIsDisabled(false));

--- a/src/components/textinput.js
+++ b/src/components/textinput.js
@@ -7,6 +7,7 @@
     const {
       actionVariableId: name,
       autoComplete,
+      autoFocus,
       disabled,
       error,
       label,
@@ -67,6 +68,7 @@
     const parsedLabel = useText(label);
     const labelText = parsedLabel;
     const debouncedOnChangeRef = useRef(null);
+    const inputRef = useRef();
 
     const { current: labelControlRef } = useRef(generateUUID());
 
@@ -204,10 +206,16 @@
       handleValidation(validity);
     };
 
+    const focusHandler = () =>
+      setTimeout(() => {
+        inputRef.current.focus();
+      }, 50);
+
     B.defineFunction('Clear', () => setCurrentValue(''));
     B.defineFunction('Enable', () => setIsDisabled(false));
     B.defineFunction('Disable', () => setIsDisabled(true));
     B.defineFunction('Reset', () => setCurrentValue(useText(value)));
+    B.defineFunction('Focus', () => focusHandler());
 
     const handleClickShowPassword = () => {
       togglePassword(!showPassword);
@@ -281,11 +289,13 @@
         )}
         <InputCmp
           id={labelControlRef}
+          inputRef={inputRef}
           name={name}
           value={currentValue}
           type={showPassword ? 'text' : inputType}
           multiline={multiline}
           autoComplete={autoComplete ? 'on' : 'off'}
+          autoFocus={!isDev && autoFocus}
           rows={rows}
           label={labelText}
           placeholder={placeholderText}

--- a/src/prefabs/structures/TextInput/options/validation.ts
+++ b/src/prefabs/structures/TextInput/options/validation.ts
@@ -35,6 +35,7 @@ export const validation = {
   }),
 
   autoComplete: toggle('Autocomplete', { value: false }),
+  autoFocus: toggle('Auto focus on input', { value: false }),
   disabled: toggle('Disabled'),
   placeholder: variable('Placeholder'),
   helperText: variable('Helper text'),

--- a/src/prefabs/structures/TextInput/options/validation.ts
+++ b/src/prefabs/structures/TextInput/options/validation.ts
@@ -35,7 +35,7 @@ export const validation = {
   }),
 
   autoComplete: toggle('Autocomplete', { value: false }),
-  autoFocus: toggle('Auto focus on input', { value: false }),
+  autoFocus: toggle('Autofocus', { value: false }),
   disabled: toggle('Disabled'),
   placeholder: variable('Placeholder'),
   helperText: variable('Helper text'),


### PR DESCRIPTION
This feature includes a new checkbox component option to set auto focus on an input on page load, and an interaction called `Focus` to focus on an input field. When the component option is set to true for multiple inputs, only the last input will be focused on.

`const focusHandler = () => setTimeout(() => { inputRef.current.focus(); }, 0);`
[A late timeout](https://developer.mozilla.org/en-US/docs/Web/API/setTimeout#:~:text=for%20more%20details.-,Late%20timeouts,-The%20timeout%20can) is required to be able to trigger the focus interaction on inputs that are inside Dialog or DrawerSidebar components.

Link to the PFR ticket: [PFR-899](https://bettyblocks.atlassian.net/browse/PFR-899).