### PR TITLE
fix(PAGE-4710): Remove unused zone from publish prod files.

### DIFF
--- a/.github/workflows/publish_bundle_production.yml
+++ b/.github/workflows/publish_bundle_production.yml
@@ -49,11 +49,6 @@ jobs:
           AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_NL4 }}
           AZURE_BLOB_ACCOUNT_KEY: ${{ secrets.AZURE_BLOB_ACCOUNT_KEY_NL4 }}
         run: yarn upload-bundle
-      - name: upload nrfem
-        env:
-          AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_NRFEM }}
-          AZURE_BLOB_ACCOUNT_KEY: ${{ secrets.AZURE_BLOB_ACCOUNT_KEY_NRFEM }}
-        run: yarn upload-bundle
       - name: upload us2
         env:
           AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_US2 }}

--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -58,11 +58,6 @@ jobs:
           AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_NL4 }}
           AZURE_BLOB_ACCOUNT_KEY: ${{ secrets.AZURE_BLOB_ACCOUNT_KEY_NL4 }}
         run: yarn upload
-      - name: upload nrfem
-        env:
-          AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_NRFEM }}
-          AZURE_BLOB_ACCOUNT_KEY: ${{ secrets.AZURE_BLOB_ACCOUNT_KEY_NRFEM }}
-        run: yarn upload
       - name: upload us2
         env:
           AZURE_BLOB_ACCOUNT: ${{ secrets.AZURE_BLOB_ACCOUNT_US2 }}


### PR DESCRIPTION
The nrfem does not exist anymore, and thus the azure blob account is not reachable. This caused the master-pipeline to crash when trying to publish to the zones.