### PR TITLE
Fix/datetime picker show default value page 4719

### DIFF
--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -199,8 +199,8 @@
     };
 
     function convertToValidDate(dateText) {
-      if (DateFns.isValid(dateText)) {
-        const parsedValue = DateFns.parse(dateText, dateFormat);
+      if (dateText) {
+        const parsedValue = DateFns.parse(dateText, getFormat(typeComponent));
         if (isValidDate(parsedValue)) {
           return parsedValue;
         }
@@ -208,7 +208,7 @@
         const parsedValueWithSlashes = dateText.replace(/-/g, '/');
         return new Date(parsedValueWithSlashes);
       }
-      return '';
+      return undefined;
     }
 
     let DateTimeComponent;

--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -79,8 +79,8 @@
     B.defineFunction('Enable', () => setIsDisabled(false));
     B.defineFunction('Disable', () => setIsDisabled(true));
 
-    const META_API_DATE_FORMAT = 'yyyy-MM-dd';
-    const META_API_TIME_FORMAT = 'HH:mm:ss';
+    const DATA_API_DATE_FORMAT = 'yyyy-MM-dd';
+    const DATA_API_TIME_FORMAT = 'HH:mm:ss';
 
     function getFormat(typeFormat) {
       return {
@@ -107,11 +107,11 @@
             break;
           }
           case 'date': {
-            parsedDate = DateFns.parse(valueText, META_API_DATE_FORMAT);
+            parsedDate = DateFns.parse(valueText, DATA_API_DATE_FORMAT);
             break;
           }
           case 'time': {
-            parsedDate = DateFns.parse(valueText, META_API_TIME_FORMAT);
+            parsedDate = DateFns.parse(valueText, DATA_API_TIME_FORMAT);
             break;
           }
           default: {


### PR DESCRIPTION
Since it describes the format as this component receives it from the DataAPI. And not the MetaAPI.

Also:
The dates should be checked against the given date-format.
When no min/maxDate has been set, the value `undefined` should be returned, or the MUI-component will disable scrolling to other months
