### PR TITLE
fix: force floatingLabel when a value is present in dataPicker

### DIFF
--- a/src/components/dateTimePickerInput.js
+++ b/src/components/dateTimePickerInput.js
@@ -239,11 +239,16 @@
       default:
     }
 
+    // Force label above the field, when the a value is present
+    const finalFloatLabel = floatLabel || resultValue !== null;
+
     const DateTimeCmp = (
       <DateTimeComponent
         id={labelControlRef}
         classes={{
-          root: `${classes.formControl} ${floatLabel && classes.floatLabel}`,
+          root: `${classes.formControl} ${
+            finalFloatLabel && classes.floatLabel
+          }`,
         }}
         value={selectedDate}
         autoComplete={autoComplete ? 'on' : 'off'}


### PR DESCRIPTION
This is to prevent the label to fall over the content, when the date / time / datetime is selected via the modal-picker