### PR TITLE
feat: include value of Select component in page state PFR-924

### DIFF
--- a/src/components/selectInput.js
+++ b/src/components/selectInput.js
@@ -70,7 +70,7 @@
       ? JSON.stringify({ uuid: defaultValueText })
       : defaultValueText || placeholderLabelText;
 
-    const [currentValue, setCurrentValue] = useState(resolvedCurrentValue);
+    const [currentValue, setCurrentValue] = usePageState(resolvedCurrentValue);
 
     useEffect(() => {
       setCurrentValue(resolvedCurrentValue);


### PR DESCRIPTION
There is currently only [a handful of components](https://github.com/search?q=repo%3Abettyblocks%2Fmaterial-ui-component-set%20path%3A%2F%5Esrc%5C%2Fcomponents%5C%2F%2F%20usePageState&type=code) (RatingInput, CheckboxInput, TextInput, DataList and DataTable) that can hold a value in the page state. It would be nice to add the SelectInput component to that collection, because I came across a use case where it was needed.

See [PFR-924](https://bettyblocks.atlassian.net/browse/PFR-924) for more information.