### PR TITLE
fix: rely on use-page-state to get the current value

### DIFF
--- a/src/components/checkboxinput.js
+++ b/src/components/checkboxinput.js
@@ -43,10 +43,6 @@
     const helperTextResolved = useText(helperText);
     const validationValueMissingText = useText(validationValueMissing);
 
-    useEffect(() => {
-      setChecked(boolify(resolvedValue));
-    }, [resolvedValue]);
-
     const {
       Checkbox: MUICheckbox,
       Switch,

--- a/src/components/ratingInput.js
+++ b/src/components/ratingInput.js
@@ -43,7 +43,6 @@
 
     const value = useText(defaultValue, { rawValue: true });
     useEffect(() => {
-      setCurrentValue(value);
       B.defineFunction('Clear', () => setCurrentValue(''));
       B.defineFunction('Enable', () => setIsDisabled(false));
       B.defineFunction('Disable', () => setIsDisabled(true));

--- a/src/components/textinput.js
+++ b/src/components/textinput.js
@@ -90,10 +90,6 @@
     const helperTextResolved = useText(helperText);
     const dataComponentAttributeValue = useText(dataComponentAttribute);
 
-    useEffect(() => {
-      setCurrentValue(optionValue);
-    }, [optionValue]);
-
     const validationMessage = (validityObject) => {
       if (validityObject.customError && patternMismatchMessage) {
         return patternMismatchMessage;


### PR DESCRIPTION
The reversed code solved a bug that only occured when the input-component was iterated. When a component is iterated, it would trigger some code in the compiler that didn't perfectly handle the state.

But the solve broke a use-case, where component is in a conditional, and the state is persisted when the component is temporarily not on the page.

By reverting this code, and fixing the compiler, all use-cases now work.