### PR TITLE
fix: show action variable selector

### DIFF
--- a/src/prefabs/autocompleteInput.tsx
+++ b/src/prefabs/autocompleteInput.tsx
@@ -226,14 +226,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/checkboxGroupInput.tsx
+++ b/src/prefabs/checkboxGroupInput.tsx
@@ -227,14 +227,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/checkboxinput.tsx
+++ b/src/prefabs/checkboxinput.tsx
@@ -220,15 +220,8 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
+
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,
             value: [variableName],

--- a/src/prefabs/datePickerInput.tsx
+++ b/src/prefabs/datePickerInput.tsx
@@ -221,14 +221,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
 
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({

--- a/src/prefabs/dateTimePickerInput.tsx
+++ b/src/prefabs/dateTimePickerInput.tsx
@@ -220,14 +220,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/decimalinput.tsx
+++ b/src/prefabs/decimalinput.tsx
@@ -216,14 +216,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/emailinput.tsx
+++ b/src/prefabs/emailinput.tsx
@@ -221,14 +221,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/fileUploadInput.tsx
+++ b/src/prefabs/fileUploadInput.tsx
@@ -180,14 +180,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/hiddeninput.tsx
+++ b/src/prefabs/hiddeninput.tsx
@@ -270,14 +270,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/ibaninput.tsx
+++ b/src/prefabs/ibaninput.tsx
@@ -220,14 +220,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/imageUploadInput.tsx
+++ b/src/prefabs/imageUploadInput.tsx
@@ -189,14 +189,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/multiAutocomplete.tsx
+++ b/src/prefabs/multiAutocomplete.tsx
@@ -213,14 +213,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/numberinput.tsx
+++ b/src/prefabs/numberinput.tsx
@@ -216,14 +216,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/passwordinput.tsx
+++ b/src/prefabs/passwordinput.tsx
@@ -213,14 +213,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/phoneinput.tsx
+++ b/src/prefabs/phoneinput.tsx
@@ -222,14 +222,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/priceinput.tsx
+++ b/src/prefabs/priceinput.tsx
@@ -226,14 +226,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/radioinput.tsx
+++ b/src/prefabs/radioinput.tsx
@@ -228,14 +228,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/ratingInput.tsx
+++ b/src/prefabs/ratingInput.tsx
@@ -216,14 +216,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/richTextInput.tsx
+++ b/src/prefabs/richTextInput.tsx
@@ -213,14 +213,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/selectinput.tsx
+++ b/src/prefabs/selectinput.tsx
@@ -228,14 +228,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/structures/AutocompleteInput/options/index.ts
+++ b/src/prefabs/structures/AutocompleteInput/options/index.ts
@@ -16,9 +16,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/CheckboxGroup/options/index.ts
+++ b/src/prefabs/structures/CheckboxGroup/options/index.ts
@@ -17,9 +17,6 @@ export const checkboxGroupInputOptions = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/CheckboxInput/options/index.ts
+++ b/src/prefabs/structures/CheckboxInput/options/index.ts
@@ -15,9 +15,6 @@ export const checkboxInputOptions = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/DateTimePicker/options/index.ts
+++ b/src/prefabs/structures/DateTimePicker/options/index.ts
@@ -16,9 +16,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/structures/FileUpload/options/advanced.ts
+++ b/src/prefabs/structures/FileUpload/options/advanced.ts
@@ -1,4 +1,4 @@
-import { variable, showIf, option } from '@betty-blocks/component-sdk';
+import { variable, option } from '@betty-blocks/component-sdk';
 
 export const advanced = {
   nameAttribute: variable('name attribute', {
@@ -10,8 +10,5 @@ export const advanced = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Name',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 };

--- a/src/prefabs/structures/MultiAutoCompleteInput/options/index.ts
+++ b/src/prefabs/structures/MultiAutoCompleteInput/options/index.ts
@@ -17,9 +17,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/PriceInput/options/index.ts
+++ b/src/prefabs/structures/PriceInput/options/index.ts
@@ -2,7 +2,6 @@ import {
   hideIf,
   option,
   property,
-  showIf,
   text,
   variable,
 } from '@betty-blocks/component-sdk';
@@ -20,9 +19,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/structures/RadioInput/options/index.ts
+++ b/src/prefabs/structures/RadioInput/options/index.ts
@@ -16,9 +16,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/RatingInput/options/index.ts
+++ b/src/prefabs/structures/RatingInput/options/index.ts
@@ -7,7 +7,6 @@ import {
   icon,
   option,
   property,
-  showIf,
   size,
   sizes,
   toggle,
@@ -44,9 +43,6 @@ export const ratingInputOptions = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
   property: property('Property', {
     value: '',

--- a/src/prefabs/structures/RichTextInput/options/index.ts
+++ b/src/prefabs/structures/RichTextInput/options/index.ts
@@ -2,7 +2,6 @@ import {
   hideIf,
   option,
   property,
-  showIf,
   toggle,
   variable,
 } from '@betty-blocks/component-sdk';
@@ -59,9 +58,6 @@ export const richTextOptions = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/structures/SelectInput/options/index.ts
+++ b/src/prefabs/structures/SelectInput/options/index.ts
@@ -17,9 +17,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/structures/TextArea/options/index.ts
+++ b/src/prefabs/structures/TextArea/options/index.ts
@@ -2,7 +2,6 @@ import {
   hideIf,
   option,
   property,
-  showIf,
   text,
   toggle,
   variable,
@@ -15,9 +14,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/structures/TextInput/options/index.ts
+++ b/src/prefabs/structures/TextInput/options/index.ts
@@ -2,7 +2,6 @@ import {
   hideIf,
   option,
   property,
-  showIf,
   variable,
 } from '@betty-blocks/component-sdk';
 import { advanced } from './advanced';
@@ -13,9 +12,6 @@ export const options = {
   actionVariableId: option('ACTION_JS_VARIABLE', {
     label: 'Action input variable',
     value: '',
-    configuration: {
-      condition: showIf('property', 'EQ', ''),
-    },
   }),
 
   property: property('Property', {

--- a/src/prefabs/switch.tsx
+++ b/src/prefabs/switch.tsx
@@ -232,14 +232,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/textareainput.tsx
+++ b/src/prefabs/textareainput.tsx
@@ -222,14 +222,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/textinput.tsx
+++ b/src/prefabs/textinput.tsx
@@ -213,14 +213,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,
@@ -313,7 +305,7 @@ const attributes = {
 
 export default prefab('Text Field', attributes, beforeCreate, [
   TextInput({
-    label: 'Text field',
+    label: 'Text field 1',
     inputLabel: 'Text field',
     type: 'text',
   }),

--- a/src/prefabs/timePickerInput.tsx
+++ b/src/prefabs/timePickerInput.tsx
@@ -220,14 +220,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,

--- a/src/prefabs/urlinput.tsx
+++ b/src/prefabs/urlinput.tsx
@@ -220,14 +220,6 @@ const beforeCreate = ({
           setOption(newPrefab.structure[0], actionVariableOption, (option) => ({
             ...option,
             value: variableName,
-            configuration: {
-              condition: {
-                type: 'SHOW',
-                option: 'property',
-                comparator: 'EQ',
-                value: '',
-              },
-            },
           }));
           setOption(newPrefab.structure[0], labelOptionKey, (option) => ({
             ...option,


### PR DESCRIPTION
When adding a new input component to a form the user selects a property, but doesn't know which action input variable is linked to that input. This fix will show the action variable selector again so the user can see the input variable. Also, when duplicating an input component, you can't assign the same action input variable. Now we clear the option in the pagebuilder and show the action variable selector option.