### PR TITLE
fix: make "Redirect when no result" option work with auth profile TECHSUP-9627

### DIFF
--- a/src/components/dataContainer.js
+++ b/src/components/dataContainer.js
@@ -211,6 +211,9 @@
                 B.defineFunction('Refetch', () => {
                   refetch();
                 });
+                if (!data && redirectWithoutResult && !loading) {
+                  redirect();
+                }
                 return DataContainer(!!data);
               }}
             </GetMe>


### PR DESCRIPTION
Currently, the option "Redirect when no result" does not work in combination with an authentication profile which leads to confusion and unnecessary workarounds. This fix enables the builder to use the "Redirect when no result" option when using an authentication profile as well.

The TECHSUP ticket: [TECHSUP-9627](https://bettyblocks.atlassian.net/browse/TECHSUP-9627).