### PR TITLE
feat: add icon, icon position and icon color options to expansion panel PFR-952

### DIFF
--- a/src/components/expansionPanel.js
+++ b/src/components/expansionPanel.js
@@ -21,6 +21,8 @@
       square,
       variant,
       elevation,
+      icon,
+      iconPosition,
       dataComponentAttribute,
       preLoadData,
     } = options;
@@ -92,7 +94,10 @@
 
     const panelSummaryOptions = {
       onClick,
-      expandIcon: <Icon name="ExpandMore" />,
+      expandIcon: <Icon name={icon} />,
+      IconButtonProps: {
+        edge: iconPosition,
+      },
     };
 
     const ShowChilderen = <>{dataShown || isDev ? children : ''}</>;
@@ -226,6 +231,13 @@
             getSpacing(outerSpacing[2], 'Desktop'),
           marginLeft: ({ options: { outerSpacing } }) =>
             getSpacing(outerSpacing[3], 'Desktop'),
+        },
+        '& .MuiExpansionPanelSummary-root': {
+          flexDirection: ({ options: { iconPosition } }) =>
+            iconPosition === 'start' && 'row-reverse',
+        },
+        '& .MuiExpansionPanelSummary-expandIcon': {
+          color: ({ options: { iconColor } }) => style.getColor(iconColor),
         },
       },
       empty: {

--- a/src/prefabs/structures/ExpansionPanel/options/index.ts
+++ b/src/prefabs/structures/ExpansionPanel/options/index.ts
@@ -4,6 +4,9 @@ import {
   option,
   showIf,
   sizes,
+  icon,
+  color,
+  ThemeColor,
 } from '@betty-blocks/component-sdk';
 import { styles } from './styles';
 import { advanced } from '../../advanced';
@@ -73,6 +76,20 @@ export const expansionPanelOptions = {
       condition: showIf('variant', 'EQ', 'elevation'),
     },
   }),
+  icon: icon('Icon', { value: 'ExpandMore' }),
+  iconPosition: option('CUSTOM', {
+    label: 'Icon position',
+    value: 'end',
+    configuration: {
+      as: 'BUTTONGROUP',
+      dataType: 'string',
+      allowedInput: [
+        { name: 'Start', value: 'start' },
+        { name: 'End', value: 'end' },
+      ],
+    },
+  }),
+  iconColor: color('Icon color', { value: ThemeColor.DARK }),
   ...styles,
 
   outerSpacing: sizes('Outer space', {


### PR DESCRIPTION
This pull request includes the following features:

- The option to set a different dropdown icon. In the current Material UI set there are 4 options: "ArrowDownward", "ArrowDropDown", "ArrowDropDownCircle", and "ExpandMore".
- The option to change the position of the icon. Either show the dropdown icon at the start or at the end.
- The option to change the color of the icon. In some designs you need to adjust the color to the customer's theming.

Link to the PFR ticket: [PFR-952](https://bettyblocks.atlassian.net/browse/PFR-952).