### PR TITLE
Fix/rich text value not serializing correctly page 4765

### DIFF
--- a/src/components/richTextInput.js
+++ b/src/components/richTextInput.js
@@ -124,11 +124,7 @@
 
     const sanitizeHTML = (rawString) => {
       // Replace all the whitespace between tags with nothing. Replacement is done when there is ONLY whitespace
-      return rawString
-        .toString()
-        .trimLeft()
-        .trimRight()
-        .replace(/>\s+</g, '><');
+      return rawString.toString().trim().replace(/>\s+</g, '><');
     };
 
     const optionValue = sanitizeHTML(useText(valueProp));
@@ -358,9 +354,9 @@
         nodeAttributes = { ...nodeAttributes, ...TEXT_TAGS[nodeName](el) };
       }
 
-      const children = Array.from(parent.childNodes)
-        .map((node) => deserialize(node, nodeAttributes))
-        .flat();
+      const children = Array.from(parent.childNodes).flatMap((node) =>
+        deserialize(node, nodeAttributes),
+      );
 
       if (children.length === 0) {
         children.push(jsx('text', nodeAttributes, ''));
@@ -375,11 +371,6 @@
         const attrs = ELEMENT_TAGS[nodeName](el);
         return jsx('element', attrs, children);
       }
-
-      // if (!Element.isElementList(children)) {
-      //   const attrs = ELEMENT_TAGS.P(el);
-      //   children = jsx('element', attrs, children);
-      // }
 
       return children;
     };

--- a/src/components/richTextInput.js
+++ b/src/components/richTextInput.js
@@ -124,14 +124,14 @@
 
     const sanitizeHTML = (rawString) => {
       // Replace all the whitespace between tags with nothing. Replacement is done when there is ONLY whitespace
-      return useText(rawString)
+      return rawString
         .toString()
         .trimLeft()
         .trimRight()
         .replace(/>\s+</g, '><');
     };
 
-    const optionValue = sanitizeHTML(valueProp);
+    const optionValue = sanitizeHTML(useText(valueProp));
     const [currentValue, setCurrentValue] = useState(optionValue);
 
     useEffect(() => {
@@ -341,7 +341,7 @@
       }
 
       const { nodeName } = el;
-      const nodeAttributes = { ...markAttributes };
+      let nodeAttributes = { ...markAttributes };
       let parent = el;
 
       if (
@@ -358,7 +358,7 @@
         nodeAttributes = { ...nodeAttributes, ...TEXT_TAGS[nodeName](el) };
       }
 
-      let children = Array.from(parent.childNodes)
+      const children = Array.from(parent.childNodes)
         .map((node) => deserialize(node, nodeAttributes))
         .flat();
 


### PR DESCRIPTION
And also leading- and trailing whitespaces.

Removing is only done between closing and opening of tags: not inside
the tags, so we don't change user-input.

This is done because Slate builds a node-tree of the tags, and gets
confused by enters in between tags
