### PR TITLE
Feat/rich text remove after delete hook page 5033

### DIFF
--- a/src/prefabs/hooks/deleteActionVariable.ts
+++ b/src/prefabs/hooks/deleteActionVariable.ts
@@ -1,8 +1,0 @@
-export const deleteActionVariable = {
-  query: 'DeleteActionVariable',
-  input: {
-    id: {
-      ref: ['options', 'actionVariableId'],
-    },
-  },
-};

--- a/src/prefabs/structures/RichTextInput/index.ts
+++ b/src/prefabs/structures/RichTextInput/index.ts
@@ -1,10 +1,7 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { updateOption } from '../../../utils';
-import { deleteActionVariable } from '../../hooks/deleteActionVariable';
 import { Configuration } from '../Configuration';
 import { richTextOptions, categories as defaultCategories } from './options';
-
-const $afterDelete = [deleteActionVariable];
 
 export const RichTextInput = (
   config: Configuration,
@@ -26,7 +23,7 @@ export const RichTextInput = (
 
   return component(
     'RichTextInput',
-    { label: config.label, options, ref, $afterDelete, optionCategories },
+    { label: config.label, options, ref, optionCategories },
     children,
   );
 };


### PR DESCRIPTION
The afterDeleteHook deletes the action-variable.
But the DeleteComponent does that as well, and more. But to do that, it needs the action-variable to still be present.

The afterDeleteHook caused a race condition with the DeleteComponent and broke the updating of the ActionStepMapping.
