### PR TITLE
fix: apply full width to submit and action buttons on smaller devices TECHSUP-10124

### DIFF
--- a/src/components/actionJSButton.js
+++ b/src/components/actionJSButton.js
@@ -364,6 +364,12 @@
         border: 'none',
         background: 'transparent',
         padding: 0,
+        width: ({ options: { fullWidth, outerSpacing } }) =>
+          !fullWidth
+            ? 'auto'
+            : `calc(100% - ${getSpacing(outerSpacing[1])} - ${getSpacing(
+                outerSpacing[3],
+              )})`,
         marginTop: ({ options: { outerSpacing } }) =>
           getSpacing(outerSpacing[0]),
         marginRight: ({ options: { outerSpacing } }) =>

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -381,6 +381,12 @@
         border: 'none',
         background: 'transparent',
         padding: 0,
+        width: ({ options: { fullWidth, outerSpacing } }) =>
+          !fullWidth
+            ? 'auto'
+            : `calc(100% - ${getSpacing(outerSpacing[1])} - ${getSpacing(
+                outerSpacing[3],
+              )})`,
         marginTop: ({ options: { outerSpacing } }) =>
           getSpacing(outerSpacing[0]),
         marginRight: ({ options: { outerSpacing } }) =>


### PR DESCRIPTION
Full width is correctly applied to the default button, open page button and logout button. Only the submit button and action button show unexpected behavior. The exact same CSS rule is applied to make it consistent (copied from the `linkComponent` style: https://github.com/bettyblocks/material-ui-component-set/blob/5b06a333152539d1b1cc7ae855b535f2d872fe50/src/components/button.js#L316-L321). 

See [TECHSUP-10124](https://bettyblocks.atlassian.net/browse/TECHSUP-10124) for more information.