### PR TITLE
fix: use display flex for tabs so left side tabs don't push content down

### DIFF
--- a/src/components/tabs.js
+++ b/src/components/tabs.js
@@ -284,7 +284,7 @@
               style.getFontSize(font, 'Desktop'),
           },
         },
-        display: 'grid',
+        display: 'flex',
         height: ({ options: { height } }) => (isDev ? '100%' : height),
         width: ({ options: { width } }) => (isDev ? '100%' : width),
         flexDirection: ({ options: { alignment } }) => {


### PR DESCRIPTION
This reverts issue PAGE-3551, but when testing this ticket it doesn't occur anymore when using flex. When PAGE-3551 occurs again, we may need to enrich the alignment configuration.