### PR TITLE
fix: min and max values should be validated in a number input

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dist"
   ],
   "dependencies": {
-    "@betty-blocks/component-sdk": "^1.91.0",
+    "@betty-blocks/component-sdk": "^1.91.1",
     "@date-io/date-fns": "^1.3.13",
     "@material-ui/core": "^4.9.11",
     "@material-ui/icons": "^4.11.2",

--- a/src/prefabs/numberinput.ts
+++ b/src/prefabs/numberinput.ts
@@ -1,5 +1,5 @@
 import { Icon, prefab } from '@betty-blocks/component-sdk';
-import { TextInput } from './structures/TextInput';
+import { DecimalInput } from './structures';
 
 const attributes = {
   category: 'FORM',
@@ -8,11 +8,10 @@ const attributes = {
 };
 
 export default prefab('Number', attributes, undefined, [
-  TextInput({
+  DecimalInput({
     label: 'Number field',
     inputLabel: 'Number',
     inputType: 'number',
     type: 'number',
-    pattern: '^[0-9]*$',
   }),
 ]);

--- a/src/prefabs/questionnaire/numberWidget.ts
+++ b/src/prefabs/questionnaire/numberWidget.ts
@@ -15,7 +15,7 @@ import {
   wrapper,
 } from '@betty-blocks/component-sdk';
 import { options as formOptions } from '../structures/ActionJSForm/options';
-import { Box, TextInput, boxOptions, textInputOptions } from '../structures';
+import { Box, DecimalInput, boxOptions, textInputOptions } from '../structures';
 
 export const numberWidget = [
   wrapper(
@@ -143,12 +143,12 @@ export const numberWidget = [
               },
             },
             [
-              TextInput(
+              DecimalInput(
                 {
                   label: 'Number field',
                   inputLabel: 'Number',
                   type: 'number',
-                  pattern: '^[0-9]*$',
+                  inputType: 'number',
                   ref: { id: '#numberInput' },
                   options: {
                     ...textInputOptions,

--- a/src/prefabs/structures/DecimalInput/index.ts
+++ b/src/prefabs/structures/DecimalInput/index.ts
@@ -1,7 +1,10 @@
 import { component, PrefabReference } from '@betty-blocks/component-sdk';
 import { options } from './options';
 import { Configuration } from '../Configuration';
-import { addChildOptions, optionEvents } from '../TextInput/options/addChild';
+import {
+  addChildOptions as defaultAddChildOptions,
+  optionEvents,
+} from '../TextInput/options/addChild';
 import { updateOption } from '../../../utils';
 
 export const DecimalInput = (
@@ -15,6 +18,22 @@ export const DecimalInput = (
   if (config.inputLabel) {
     options.label = updateOption(options.label, { value: [config.inputLabel] });
   }
+
+  if (config.type === 'number') {
+    options.decimalScale = updateOption(options.decimalScale, {
+      label: 'Decimal scale',
+      value: 0,
+    });
+
+    options.showGroupSeparator = updateOption(options.showGroupSeparator, {
+      value: false,
+    });
+  }
+
+  const addChildOptions = [
+    ...(config.optionTemplates?.addChild?.options ||
+      defaultAddChildOptions(config.inputType || 'decimal')),
+  ];
 
   const categories = [
     {
@@ -62,7 +81,7 @@ export const DecimalInput = (
       optionCategories: categories,
       optionTemplates: {
         addChild: {
-          options: addChildOptions('decimal'),
+          options: addChildOptions,
           optionEvents,
         },
       },

--- a/src/prefabs/structures/DecimalInput/options/index.ts
+++ b/src/prefabs/structures/DecimalInput/options/index.ts
@@ -53,15 +53,21 @@ export const options = {
     ],
     {
       value: ',',
+      configuration: {
+        condition: hideIf('decimalScale', 'EQ', 0),
+      },
     },
   ),
 
   decimalScale: number('Scale', {
-    value: '2',
+    value: 2,
   }),
 
   showGroupSeparator: toggle('Show group (thousands) separator', {
     value: true,
+    configuration: {
+      condition: hideIf('decimalScale', 'EQ', 0),
+    },
   }),
 
   ...validation,

--- a/yarn.lock
+++ b/yarn.lock
@@ -196,10 +196,10 @@
   optionalDependencies:
     isolated-vm "^4.0.0"
 
-"@betty-blocks/component-sdk@^1.91.0":
-  version "1.91.0"
-  resolved "https://registry.yarnpkg.com/@betty-blocks/component-sdk/-/component-sdk-1.91.0.tgz#98786209e9ec457d7105e26409c1f42574a565a3"
-  integrity sha512-hI9ZfpHU0/5bnpd8qZD13E893uR3qmgRrZ30AxKTG5StZcp2mYMnwFwF/5iYdQzjCQHEekg/mTvevRbWGJ1Viw==
+"@betty-blocks/component-sdk@^1.91.1":
+  version "1.91.1"
+  resolved "https://registry.yarnpkg.com/@betty-blocks/component-sdk/-/component-sdk-1.91.1.tgz#805a99f94c491dd224d86f58586bd703f896277a"
+  integrity sha512-4TOobgLSIVt3lC8qYzeXA6arS5sV3oZNj8prUZnQn+/IZF60z8BuG2xixv2mRtEVzpzWGT45+r8i2KSm9bm7WA==
 
 "@colors/colors@1.5.0":
   version "1.5.0"


### PR DESCRIPTION
By using the Decimal component with a scale of 0 we ensure it is a number input which has options for number based components