### PR TITLE
fix: prevent cyclic render loop by catching the event on state updates

### DIFF
--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -731,6 +731,11 @@
             setDebouncedCurrentValue(newValue);
           }}
           onInputChange={(event, newValue) => {
+            if (!event) {
+              // state updates cause this event to equal null
+              // nothing should happen then, to prevent a rerender cycle
+              return;
+            }
             let validation = event ? event.target.validity : null;
             if (isNumberType) {
               validation = customPatternValidation(event.target);


### PR DESCRIPTION
When used in the pages-compiler, this component keeps rendering because of all the state updates. To avoid this cyclic rerender without rewriting the whole component, I added a condition to the onInputChange function. Apparently this gets `event: null` on state updates. 