### PR TITLE
fix: add debouncedCurrentValue to the autocomplete condition 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.212.14](https://github.com/bettyblocks/material-ui-component-set/compare/v2.212.13...v2.212.14) (2025-04-30)
+
+
+### Bug Fixes
+
+* dont clear the value in autocomplete while rerendering ([4e1aa2a](https://github.com/bettyblocks/material-ui-component-set/commit/4e1aa2aa9a21dfb9a21561d2d2ab21c3049b3fa1))
+
 ## [2.212.13](https://github.com/bettyblocks/material-ui-component-set/compare/v2.212.12...v2.212.13) (2025-04-29)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.212.15](https://github.com/bettyblocks/material-ui-component-set/compare/v2.212.14...v2.212.15) (2025-05-02)
+
+
+### Bug Fixes
+
+* usePageState for decimal based inputs ([8f3ea89](https://github.com/bettyblocks/material-ui-component-set/commit/8f3ea896910b3e3eb24ceee8fdcd7025194db2f9))
+
 ## [2.212.14](https://github.com/bettyblocks/material-ui-component-set/compare/v2.212.13...v2.212.14) (2025-04-30)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.212.14",
+  "version": "2.212.15",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.212.13",
+  "version": "2.212.14",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -649,8 +649,8 @@
     const currentValue = getValue();
 
     useEffect(() => {
-      if (currentValue === null) {
-        // state updates cause currentValue to equal null
+      if (currentValue === null && !debouncedCurrentValue) {
+        // state updates cause currentValue to equal null and debouncedCurrentValue is empty
         // nothing should happen then, to prevent a unwanted reset of the value
         return;
       }


### PR DESCRIPTION
This condition is added for using the pages compiler.
It prevents unwanted clearing of the value, however it should clear when using the clear interaction.