### PR TITLE
fix: heap-size for lint crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "build-fast": "bb components build --fast",
     "dev": "nodemon",
     "dev:fast": "nodemon --config nodemonfast.json",
-    "lint": "eslint --ext .js,.ts,.tsx ./src",
+    "lint": "NODE_OPTIONS=--max-old-space-size=8196 eslint --ext .js,.ts,.tsx ./src",
     "lint:ci": "yarn lint --max-warnings 0",
     "prettier:base": "prettier --single-quote",
     "prettier:check": "yarn prettier:base --list-different \"src/**/*.js\"",


### PR DESCRIPTION
If you try to commit without using --no-verify the precommit lint will fail due to not having enough memory.
`FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory`

This extra ENV variable in the lint command adds 6gb extra ram in order for it not to crash.