### PR TITLE
fix: revert position to relative in design time PFR

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -345,7 +345,7 @@
           '!important',
         ],
         ...(isDev && {
-          position: 'absolute',
+          position: 'relative',
           pointerEvents: ['unset', '!important'],
           zIndex: 9,
         }),


### PR DESCRIPTION
> The CSS rule `position: absolute;` makes sure that the design time appearance reflects the runtime appearance.

The above change resulted in some unexpected behavior, so I'm reverting this.

For more information, see [PFR-1062](https://bettyblocks.atlassian.net/browse/PFR-1062).