### PR TITLE
feat: allow BODY_COMPONENT and CONTAINER_COMPONENT types as children in Menu PFR-1062

### DIFF
--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -345,7 +345,7 @@
           '!important',
         ],
         ...(isDev && {
-          position: 'absolute',
+          position: 'relative',
           pointerEvents: ['unset', '!important'],
           zIndex: 9,
         }),

--- a/src/components/menu.js
+++ b/src/components/menu.js
@@ -1,7 +1,7 @@
 (() => ({
   name: 'Menu',
   type: 'CONTENT_COMPONENT',
-  allowedTypes: ['MENU_ITEM'],
+  allowedTypes: ['MENU_ITEM', 'BODY_COMPONENT', 'CONTAINER_COMPONENT'],
   orientation: 'VERTICAL',
   jsx: (() => {
     const {
@@ -271,6 +271,7 @@
         marginLeft: ({ options: { outerSpacing } }) =>
           getSpacing(outerSpacing[3]),
         '&.MuiButton-root, &.MuiIconButton-root': {
+          textTransform: 'none',
           [`@media ${mediaMinWidth(600)}`]: {
             width: ({ options: { fullWidth, outerSpacing } }) => {
               if (!fullWidth) return 'auto';
@@ -344,7 +345,7 @@
           '!important',
         ],
         ...(isDev && {
-          position: 'relative',
+          position: 'absolute',
           pointerEvents: ['unset', '!important'],
           zIndex: 9,
         }),


### PR DESCRIPTION
* Bonus: the CSS rule `text-transform: none;` allows you to have a menu button without all uppercased characters.

For more information, see [PFR-1062](https://bettyblocks.atlassian.net/browse/PFR-1062).