### PR TITLE
feat: add "Display Rich Text" checkbox option to dynamically show HTML content PFR-945

### DIFF
--- a/src/components/alert.js
+++ b/src/components/alert.js
@@ -15,6 +15,7 @@
       bodyText,
       allowTextServerResponse,
       allowTitleServerResponse,
+      useInnerHtml,
       dataComponentAttribute,
     } = options;
     const title = useText(titleText);
@@ -23,6 +24,7 @@
     const [open, setOpen] = useState(visible);
     const [titleFromServer, setTitleFromServer] = useState('');
     const [textFromServer, setTextFromServer] = useState('');
+    const alertBody = (allowTextServerResponse && textFromServer) || body;
 
     useEffect(() => {
       setOpen(visible);
@@ -125,7 +127,15 @@
               : title}
           </AlertTitle>
         )}
-        {textFromServer && allowTextServerResponse ? textFromServer : body}
+        {useInnerHtml ? (
+          <div
+            className={classes.htmlContent}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: alertBody }}
+          />
+        ) : (
+          alertBody
+        )}
       </Alert>
     );
     return isDev ? (
@@ -207,6 +217,11 @@
             fontSize: ({ options: { font } }) =>
               style.getFontSize(font, 'Desktop'),
           },
+        },
+      },
+      htmlContent: {
+        '& *': {
+          color: ({ options: { textColor } }) => style.getColor(textColor),
         },
       },
       hide: {

--- a/src/prefabs/structures/Alert/options/index.ts
+++ b/src/prefabs/structures/Alert/options/index.ts
@@ -22,6 +22,7 @@ export const categories = [
       'iconColor',
       'background',
       'borderColor',
+      'useInnerHtml',
     ],
   },
   {
@@ -76,6 +77,9 @@ export const alertOptions = {
   }),
   borderColor: color('Border color', {
     value: ThemeColor.TRANSPARENT,
+  }),
+  useInnerHtml: toggle('Display Rich Text', {
+    value: false,
   }),
   icon: icon('Icon', {
     value: 'None',


### PR DESCRIPTION
Added a checkbox option "Display Rich Text" to the Alert, similar to the checkbox option in [the Text prefab](https://github.com/bettyblocks/material-ui-component-set/blob/d5d1b3e754567d12816bec7a47fcc15c9f5f7de2/src/prefabs/structures/Text/options/index.ts#L33). With this option, you are able to return rich text from the action, and show it as HTML content in the Alert. For example, to highlight certain words or to include an inline text link.

Link to the PFR ticket: [PFR-945](https://bettyblocks.atlassian.net/browse/PFR-945).