### PR TITLE
feat: trigger onClick interaction for submit and action button PFR-929 & PFR-1075

### DIFF
--- a/src/components/button.js
+++ b/src/components/button.js
@@ -148,6 +148,7 @@
       tabIndex: isDev ? -1 : undefined,
       onClick: (event) => {
         event.stopPropagation();
+        B.triggerEvent('onClick');
         actionCallback();
       },
       role: 'button',


### PR DESCRIPTION
After implementing https://github.com/bettyblocks/material-ui-component-set/pull/3747, the OnClick trigger does not work anymore for the submit button. This change makes sure to enable this feature again.

For more information, see [PFR-929](https://bettyblocks.atlassian.net/browse/PFR-929) & [PFR-1075](https://bettyblocks.atlassian.net/browse/PFR-1075).