### PR TITLE
Fix/onclick event button component page 5566

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [2.224.1](https://github.com/bettyblocks/material-ui-component-set/compare/v2.224.0...v2.224.1) (2025-09-02)
+
+
+### Bug Fixes
+
+* set inner spacing and background color of Box in detail view ([804ce8f](https://github.com/bettyblocks/material-ui-component-set/commit/804ce8fe23116f3a454bcdfa0f16912686d270b9))
+
 # [2.224.0](https://github.com/bettyblocks/material-ui-component-set/compare/v2.223.0...v2.224.0) (2025-08-27)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "2.224.0",
+  "version": "2.224.1",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -148,7 +148,7 @@
       tabIndex: isDev ? -1 : undefined,
       onClick: (event) => {
         event.stopPropagation();
-        B.triggerEvent('onClick');
+        B.triggerEvent('onClick', event);
         actionCallback();
       },
       role: 'button',
@@ -193,13 +193,13 @@
 
     const handleClick = (e) => {
       e.stopPropagation();
-      B.triggerEvent('onClick');
+      B.triggerEvent('onClick', e);
     };
 
     const handleKeyUp = (e) => {
       if (e.key === 'Enter') {
         e.stopPropagation();
-        B.triggerEvent('onClick');
+        B.triggerEvent('onClick', e);
       }
     };
 


### PR DESCRIPTION
When having a click event on a button, in out prefabs we use the `Click` which is automatically added to component in the compilerJS.

When setting up an interaction and choose the Click event in the UI, the `onClick` is stored and triggered.

So we have both an event `Click` and `onClick`, where the `Click` has arguments where `onClick` doesn't. This causes issues when using a button click for setting a current record for example. That function expects arguments which aren't there when the click event is chosen via the UI. It is there in our prefabs, so that is why it works when using the back office template for example.

Anyway, this adds the event as argument to the `onClick` so it will work for both `Click` and `onClick`.