### PR TITLE
fix: handle set rebounced value via useEffect. Prevents clear value reset on first change

### DIFF
--- a/src/components/autocompleteInput.js
+++ b/src/components/autocompleteInput.js
@@ -733,7 +733,6 @@
           })}
           onChange={(_, newValue) => {
             setValue(newValue || '');
-            setDebouncedCurrentValue(newValue);
           }}
           onInputChange={(event, newValue) => {
             if (!event) {


### PR DESCRIPTION
Value on autocomplete was cleared on change in an update form (input value was still showing) causing wrong behaviour: value was cleared in the action while it was supposed to be a change of value