### PR TITLE
fix: place defined functions inside a useeffect in checkbox

### DIFF
--- a/src/components/checkboxinput.js
+++ b/src/components/checkboxinput.js
@@ -55,10 +55,6 @@
       FormGroup,
     } = window.MaterialUI.Core;
 
-    B.defineFunction('Uncheck', () => setChecked(false));
-    B.defineFunction('Check', () => setChecked(true));
-    B.defineFunction('Check/Uncheck', () => setChecked(!checked));
-
     const handleValidation = (isValid) => {
       setErrorState(!isValid);
       const message = !isValid
@@ -84,7 +80,14 @@
       handleValidation(isValid);
     };
 
-    B.defineFunction('Reset', () => setChecked(boolify(resolvedValue)));
+    useEffect(() => {
+      B.defineFunction('Reset', () => setChecked(boolify(resolvedValue)));
+      B.defineFunction('Uncheck', () => setChecked(false));
+      B.defineFunction('Check', () => setChecked(true));
+      B.defineFunction('Check/Uncheck', () =>
+        setChecked((prev) => !boolify(prev)),
+      );
+    }, []);
 
     useEffect(() => {
       if (checked) {


### PR DESCRIPTION
By placing the B.defineFunction inside a useEffect, they will be placed on the ref each render. This way we can use them in an interaction. The solution for https://bettyblocks.atlassian.net/browse/TECHSUP-11604