### PR TITLE
Fix/data table filtering with multiple inputs page 6494

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [3.7.2](https://github.com/bettyblocks/material-ui-component-set/compare/v3.7.1...v3.7.2) (2026-05-21)
+
+
+### Bug Fixes
+
+* place defined functions inside a useeffect in checkbox ([942625c](https://github.com/bettyblocks/material-ui-component-set/commit/942625c9292273dd27ce19089efc8eb57311aa0e))
+
 ## [3.7.1](https://github.com/bettyblocks/material-ui-component-set/compare/v3.7.0...v3.7.1) (2026-05-04)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "component-set",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "main": "dist/templates.json",
   "license": "UNLICENSED",
   "private": false,

--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -556,13 +556,13 @@
           );
           return;
         }
-        setInteractionFilter({
-          ...interactionFilter,
+        setInteractionFilter((prev) => ({
+          ...prev,
           [interactionId]: {
             property,
             value: event.target ? event.target.value : transformValue(event),
           },
-        });
+        }));
         setInteractionSearchTerm(
           event.target ? event.target.value : transformValue(event),
         );


### PR DESCRIPTION
The B.defineFunction 'Filter' is put inside a useEffect making the interactionFilters state value in that function a stale empty hash. Because of that every call of the Filter interaction would override the interactionFilters state causing wrong results in filtering the data table and no longer combining multiple filters.

The fix uses the previous value of the set state function which is not stale and correctly accumulates the filters.