### PR TITLE
fix: use the previous state of interaction filters in data table filter interaction

### DIFF
--- a/src/components/dataTable.js
+++ b/src/components/dataTable.js
@@ -556,13 +556,13 @@
           );
           return;
         }
-        setInteractionFilter({
-          ...interactionFilter,
+        setInteractionFilter((prev) => ({
+          ...prev,
           [interactionId]: {
             property,
             value: event.target ? event.target.value : transformValue(event),
           },
-        });
+        }));
         setInteractionSearchTerm(
           event.target ? event.target.value : transformValue(event),
         );


### PR DESCRIPTION
The B.defineFunction 'Filter' is put inside a useEffect making the interactionFilters state value in that function a stale empty hash. Because of that every call of the Filter interaction would override the interactionFilters state causing wrong results in filtering the data table and no longer combining multiple filters.

The fix uses the previous value of the set state function which is not stale and correctly accumulates the filters.