### PR TITLE
fix: pin bun version in deploy step

### DIFF
--- a/.github/workflows/publish_acceptance.yml
+++ b/.github/workflows/publish_acceptance.yml
@@ -19,7 +19,11 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 

--- a/.github/workflows/publish_bundle_acceptance.yml
+++ b/.github/workflows/publish_bundle_acceptance.yml
@@ -12,7 +12,11 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 

--- a/.github/workflows/publish_bundle_edge.yml
+++ b/.github/workflows/publish_bundle_edge.yml
@@ -10,7 +10,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 

--- a/.github/workflows/publish_bundle_production.yml
+++ b/.github/workflows/publish_bundle_production.yml
@@ -12,7 +12,11 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 

--- a/.github/workflows/publish_edge.yml
+++ b/.github/workflows/publish_edge.yml
@@ -12,7 +12,11 @@ jobs:
       - uses: actions/checkout@v2
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 

--- a/.github/workflows/publish_production.yml
+++ b/.github/workflows/publish_production.yml
@@ -18,7 +18,11 @@ jobs:
           token: ${{ secrets.GH_TOKEN }}
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          # Pinned: @betty-blocks/cli publishes via the legacy @azure/storage-blob v10
+          # SDK, whose polyfilled AbortSignal is rejected by Bun >= 1.4.0 fetch
+          # ("signal is not of type AbortSignal"). Unpin once the CLI moves to
+          # @azure/storage-blob v12.
+          bun-version: 1.3.14
       - name: Install packages
         run: bun install
 


### PR DESCRIPTION
Bun version is pinned. Version 1.4 is not compatible with our publish step. Also, it is good to use pinned versions to avoid unexpected behaviour.